### PR TITLE
open README.rst explicitly in utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ DEPENDENCIES = ['numpy', 'pandas', 'sqlalchemy', 'colorama', 'pyfiglet']
 
 def readme():
     '''Return the contents of the README.rst file.'''
-    with open('README.rst') as freadme:
+    with open('README.rst', encoding='utf8') as freadme:
         return freadme.read()
 
 


### PR DESCRIPTION
Running `setup.py` (python 3.5.2, windows 7) fails with `UnicodeDecodeError` otherwise due to default 1252 encoding.