### PR TITLE
Remove hash support since it is unsafe for mutable objects

### DIFF
--- a/mendeleev/models.py
+++ b/mendeleev/models.py
@@ -656,12 +656,11 @@ class Element(Base):
         normal_coeffs = [[str(c) if c != 1 else "" for c in t] for t in oxide_coeffs]
         return [f"{self.symbol}{cme}O{co}" for cme, co in normal_coeffs]
 
-    def __hash__(self):
-        """Custom has function to allow comparisons
+    def __eq__(self, other):
+        # Custom equality function to allow comparisons
 
-        This drops allt he nested, related objects since SQLAlchemy use a custom
-        unhashable `InstrumentedList`.
-        """
+        # This drops all the nested, related objects since SQLAlchemy
+        # use a custom unhashable `InstrumentedList`.
         to_drop = [
             "_ionization_energies",
             "_oxidation_states",
@@ -674,12 +673,11 @@ class Element(Base):
             "isotopes",
             "screening_constants",
         ]
-        hashable = [(k, v) for k, v in self.__dict__.items() if k not in to_drop]
-        return hash(tuple(sorted(hashable)))
-
-    def __eq__(self, other):
-        """Overwrite the defalt comparison"""
-        return hash(self) == hash(other)
+        for k, v in self.__dict__.items():
+            if k not in to_drop:
+                if v != getattr(other, k):
+                    return False
+        return True
 
     def __str__(self):
         return "{0} {1} {2}".format(self.atomic_number, self.symbol, self.name)


### PR DESCRIPTION
Allowing hash on mutable objects leads to strange situations. For example:
```
>>> import mendeleev
>>> H = mendeleev.element(1)
>>> myset = {H}
>>> H.atomic_weight = 2
>>> H in myset
False
>>> H in list(myset)
True
```

This PR remove the hashing support so that instead we get an error:
```
>>> import mendeleev
>>> H = mendeleev.element(1)
>>> myset = {H}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unhashable type: 'Element'
```

If you need to place elements or dict or set, you can use the `.atomic_number` property instead.
```
>>> import mendeleev
>>> H = mendeleev.element(1)
>>> myset = {H.atomic_number}
>>> H.atomic_number in myset
True
>>> H.atomic_number in list(myset)
True
```
