### PR TITLE
Use r before string constants containing literal backslashes

### DIFF
--- a/mendeleev/ciaawparser.py
+++ b/mendeleev/ciaawparser.py
@@ -58,7 +58,7 @@ def ciaaw_atomic_masses():
     df.loc[:, "is_radioactive"] = df["A"].str.contains("*", regex=False)
     df.loc[:, "A"] = df["A"].str.extract("([0-9]+)", expand=False).astype(int)
 
-    df.loc[:, "AM wows"] = df["Atomic mass,ma/Da"].str.replace("\s", "")
+    df.loc[:, "AM wows"] = df["Atomic mass,ma/Da"].str.replace(r"\s", "")
     df[["AM lead", "AM decimals", "AM unc"]] = df["AM wows"].str.extract(
         r"(\d+)\.(\d+)\((\d+)\)", expand=True
     )
@@ -99,7 +99,7 @@ def ciaaw_atomic_weights():
 
     table = table.rename(columns={"Standard Atomic Weight": "SAW"})
     table.loc[:, "Z"] = table["Z"].astype(int)
-    table.loc[:, "SAW"] = table["SAW"].str.replace("\s", "")
+    table.loc[:, "SAW"] = table["SAW"].str.replace(r"\s", "")
     table[["SAW decimals", "SAW unc"]] = table["SAW"].str.extract(
         r"\d+\.(\d+)\((\d+)\)", expand=True
     )
@@ -133,7 +133,7 @@ def ciaaw_isotopic_abundances():
     abu = "Representative isotopic composition"
     ia.loc[:, "A"] = ia["A"].str.extract("([0-9]+)", expand=False).astype(int)
     ia.loc[:, "Z"] = ia["Z"].astype(int)
-    ia.loc[:, abu] = ia[abu].str.replace("\s", "")
+    ia.loc[:, abu] = ia[abu].str.replace(r"\s", "")
     ia.loc[:, "abundance"] = ia[abu].str.extract(r"(\d+\.\d+)\(", expand=False)
     ia.loc[:, "abundance"].fillna(
         ia[abu].str.extract(r"\[(\d+\.\d+),", expand=False), inplace=True

--- a/mendeleev/electronegativity.py
+++ b/mendeleev/electronegativity.py
@@ -73,7 +73,7 @@ def li_xue(ionization_energy: float, radius: float, valence_pqn: int) -> float:
 
 
 def martynov_batsanov(ionization_energies: List[float]) -> float:
-    """
+    r"""
     Calculates the electronegativity value according to Martynov and
     Batsanov as the average of the ionization energies of the valence
     electrons
@@ -84,7 +84,7 @@ def martynov_batsanov(ionization_energies: List[float]) -> float:
 
     .. math::
 
-       \chi_{MB} = \sqrt{\\frac{1}{n_{v}}\sum^{n_{v}}_{k=1} I_{k}}
+       \chi_{MB} = \sqrt{\frac{1}{n_{v}}\sum^{n_{v}}_{k=1} I_{k}}
 
     where:
 
@@ -101,7 +101,7 @@ def mulliken(
     missing_is_zero: bool = False,
     allow_negative_ea: bool = False,
 ) -> float:
-    """
+    r"""
     Return the absolute electronegativity (Mulliken scale), calculated as
 
     Args:
@@ -112,7 +112,7 @@ def mulliken(
 
     .. math::
 
-       \chi = \\frac{I + A}{2}
+       \chi = \frac{I + A}{2}
 
     where:
 
@@ -147,7 +147,7 @@ def nagle(nvalence: int, polarizability: float) -> float:
 
 
 def sanderson(radius: float, noble_gas_radius: float) -> float:
-    """
+    r"""
     Calculate Sanderson's electronegativity
 
     Args:
@@ -157,7 +157,7 @@ def sanderson(radius: float, noble_gas_radius: float) -> float:
 
     .. math::
 
-        \chi = \\frac{AD}{AD_{\\text{ng}}}
+        \chi = \frac{AD}{AD_{\text{ng}}}
 
     """
 
@@ -165,7 +165,7 @@ def sanderson(radius: float, noble_gas_radius: float) -> float:
 
 
 def generic(zeff: float, radius: float, rpow: float = 1, apow: float = 1) -> float:
-    """
+    r"""
     Calculate the electronegativity from a general formula
 
     Args:
@@ -176,13 +176,13 @@ def generic(zeff: float, radius: float, rpow: float = 1, apow: float = 1) -> flo
 
     .. math::
 
-        \chi = \left(\\frac{Z_{\\text{eff}}}{r^{\\beta}}\\right)^{\\alpha}
+        \chi = \left(\frac{Z_{\text{eff}}}{r^{\beta}}\right)^{\alpha}
 
     where:
 
-    - :math:`Z_{\\text{eff}}` is the effective nuclear charge
+    - :math:`Z_{\text{eff}}` is the effective nuclear charge
     - :math:`r` is the covalent radius
-    - :math:`\\alpha,\\beta` parameters
+    - :math:`\alpha,\beta` parameters
     """
 
     return math.pow(zeff / math.pow(radius, rpow), apow)

--- a/mendeleev/mendeleev.py
+++ b/mendeleev/mendeleev.py
@@ -120,14 +120,14 @@ def ids_to_attr(ids, attr="atomic_number"):
 
 
 def deltaN(id1, id2, charge1=0, charge2=0, missingIsZero=True):
-    """
+    r"""
     Calculate the approximate fraction of transferred electrons between
     elements or ions `id1` and `id2` with charges `charge1` and `charge2`
     respectively according to the expression
 
     .. math::
 
-       \Delta N = \\frac{\chi_{A} - \chi_{B}}{2(\eta_{A} + \eta_{B})}
+       \Delta N = \frac{\chi_{A} - \chi_{B}}{2(\eta_{A} + \eta_{B})}
 
     Args:
       id1: str or int


### PR DESCRIPTION
Make sure to always use `r""` strings when they contain backslashes. It can be tested with
```
pytest -W error -o 'python_files=*' tests/
```

It is the assert rewrite function in pytest that triggers these warnings, and its `python_files` option (besides its main purpose of selecting test files) decides which imported modules the assert rewrite is applied to.

(see https://github.com/lmmentel/mendeleev/pull/48 for an earlier attempt that didn't catch all occurrences)