### PR TITLE
Fix URL in references.bib

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -463,7 +463,7 @@
 @misc{iupac-masses,
   author = {{IUPAC-CIAAW}},
   title  = {Atomic Masses},
-  url    = {hhttp://ciaaw.org/atomic-masses.htm},
+  url    = {https://ciaaw.org/atomic-masses.htm},
   note   = {[Online; accessed  25-September-2022, data file: https://ciaaw.org/data/IUPAC-atomic-masses.csv, last updated: 17 March 2021]}
 }
 @misc{Stone2013,


### PR DESCRIPTION
I noticed a broken link in the list of references when I was checking the source for atomic masses.