### PR TITLE
Use read-only SQLite connection

### DIFF
--- a/mendeleev/db.py
+++ b/mendeleev/db.py
@@ -17,7 +17,10 @@ def get_engine(dbpath: str = None) -> Engine:
     """Return the db engine"""
     if not dbpath:
         dbpath = get_package_dbpath()
-    return create_engine("sqlite:///{path:s}".format(path=dbpath), echo=False)
+    return create_engine(
+        "sqlite:///file:{path:s}?mode=ro&nolock=1&uri=true".format(path=dbpath),
+        echo=False
+    )
 
 
 def get_session(dbpath: str = None) -> Session:

--- a/mendeleev/db.py
+++ b/mendeleev/db.py
@@ -21,7 +21,7 @@ def get_engine(dbpath: str = None, read_only: bool = True) -> Engine:
         connectstr = "sqlite:///file:{path:s}?mode=ro&nolock=1&uri=true".format(
             path=dbpath
         )
-    else: 
+    else:
         connectstr = "sqlite:///{path:s}".format(path=dbpath)
     return create_engine(connectstr, echo=False)
 

--- a/mendeleev/db.py
+++ b/mendeleev/db.py
@@ -13,14 +13,15 @@ def get_package_dbpath() -> str:
     return os.path.join(os.path.abspath(os.path.dirname(__file__)), DBNAME)
 
 
-def get_engine(dbpath: str = None) -> Engine:
+def get_engine(dbpath: str = None, read_only: bool = True) -> Engine:
     """Return the db engine"""
     if not dbpath:
         dbpath = get_package_dbpath()
-    return create_engine(
-        "sqlite:///file:{path:s}?mode=ro&nolock=1&uri=true".format(path=dbpath),
-        echo=False,
-    )
+    if read_only:
+        connectstr = "sqlite:///file:{path:s}?mode=ro&nolock=1&uri=true".format(path=dbpath)
+    else: 
+        connectstr = "sqlite:///{path:s}".format(path=dbpath)
+    return create_engine(connectstr, echo=False)
 
 
 def get_session(dbpath: str = None) -> Session:

--- a/mendeleev/db.py
+++ b/mendeleev/db.py
@@ -19,7 +19,7 @@ def get_engine(dbpath: str = None) -> Engine:
         dbpath = get_package_dbpath()
     return create_engine(
         "sqlite:///file:{path:s}?mode=ro&nolock=1&uri=true".format(path=dbpath),
-        echo=False
+        echo=False,
     )
 
 

--- a/mendeleev/db.py
+++ b/mendeleev/db.py
@@ -26,8 +26,8 @@ def get_engine(dbpath: str = None, read_only: bool = True) -> Engine:
     return create_engine(connectstr, echo=False)
 
 
-def get_session(dbpath: str = None) -> Session:
+def get_session(dbpath: str = None, read_only: bool = True) -> Session:
     """Return the database session connection."""
-    engine = get_engine(dbpath=dbpath)
+    engine = get_engine(dbpath=dbpath, read_only=read_only)
     db_session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     return db_session()

--- a/mendeleev/db.py
+++ b/mendeleev/db.py
@@ -18,7 +18,9 @@ def get_engine(dbpath: str = None, read_only: bool = True) -> Engine:
     if not dbpath:
         dbpath = get_package_dbpath()
     if read_only:
-        connectstr = "sqlite:///file:{path:s}?mode=ro&nolock=1&uri=true".format(path=dbpath)
+        connectstr = "sqlite:///file:{path:s}?mode=ro&nolock=1&uri=true".format(
+            path=dbpath
+        )
     else: 
         connectstr = "sqlite:///{path:s}".format(path=dbpath)
     return create_engine(connectstr, echo=False)


### PR DESCRIPTION
When the `mendeleev` package is located on a Network File System (NFS) Sqlalchemy fails with an [OperationalError](https://docs.sqlalchemy.org/en/20/errors.html#operationalerror). 

```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) disk I/O error
```

This is a [known limitation of SQLite](https://www.sqlite.org/faq.html#q5):
> This is because fcntl() file locking is broken on many NFS implementations. You should avoid putting SQLite database files on NFS if multiple processes might try to access the file at the same time.

As the data in the `elements.db` file never changes, the solution is to connect to the SQLite database using [read-only mode](https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#uri-connections). This is implemented in this pull request. 

Originally reported by @pkruzikova 