### PR TITLE
Documentation restructure and sphinx-immaterial migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md — Mendeleev
+
+Pythonic periodic table library. SQLAlchemy models + SQLite db (`mendeleev/elements.db`).
+
+## Dev commands
+
+```bash
+poetry install                    # core deps only
+poetry install --with vis         # add bokeh/plotly/seaborn
+poetry run pytest                 # runs with -n auto (xdist) by default
+poetry run pytest -k "element"    # pattern match
+poetry run pytest tests/test_element.py::test_element  # single test
+poetry run pytest --cov=mendeleev # coverage
+pre-commit run --all-files        # ruff lint + format (must pass before commit)
+cd docs && poetry run make html   # build docs (needs `pip install -r docs/requirements.txt` first)
+poetry run inv render-data-docs   # regenerate data reference rst from PropertyMetadata
+poetry run inv export             # dump db tables to csv/json/html/md/sql
+```
+
+## Architecture
+
+- **`mendeleev/mendeleev.py`** — main entrypoint: `element()`, `isotope()`, `get_all_elements()`
+- **`mendeleev/models.py`** — all SQLAlchemy models (Element, Isotope, Ion, etc.)
+- **`mendeleev/db.py`** — creates read-only SQLite engine by default (URI with `?mode=ro`)
+- **`mendeleev/fetch.py`** — `fetch_table()` for pandas access
+- **`mendeleev/__init__.py`** — dynamic `__getattr__` so `from mendeleev import C` works
+- **CLI**: `element.py <symbol|name|number>` via `mendeleev.cli:clielement`
+
+## Key conventions
+
+- **Ruff only** for linting + formatting (v0.3.3). No typechecker (mypy/pyright) configured.
+- **pre-commit excludes** `alembic/` and `notebooks/`
+- Database is **read-only by default** via URI parameter. Alembic needs write access.
+- Adding a property: update model → alembic revision → upgrade → update PropertyMetadata → `inv render-data-docs`
+- Tests use `-n auto` (pytest-xdist). Set `PYTEST_ADDOPTS=""` to override.
+- CI matrix: 3 OS × 5 Python versions (3.9–3.13). Runs ruff (pre-commit) then pytest.
+- Documentation uses sphinx-material theme. Notebooks in `docs/source/notebooks/` are rendered by nbsphinx. Dev notebooks in root `notebooks/` are ignored by pre-commit.
+- Package published to PyPI on tags via trusted publishing (no password needed).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,5 +34,5 @@ poetry run inv export             # dump db tables to csv/json/html/md/sql
 - Adding a property: update model → alembic revision → upgrade → update PropertyMetadata → `inv render-data-docs`
 - Tests use `-n auto` (pytest-xdist). Set `PYTEST_ADDOPTS=""` to override.
 - CI matrix: 3 OS × 5 Python versions (3.9–3.13). Runs ruff (pre-commit) then pytest.
-- Documentation uses sphinx-material theme. Notebooks in `docs/source/notebooks/` are rendered by nbsphinx. Dev notebooks in root `notebooks/` are ignored by pre-commit.
+- Documentation uses **sphinx-immaterial** theme (fork of sphinx-material). Workaround: `object_description_options` disables `generate_synopses` to avoid a sphinx-immaterial KeyError. If upgrading sphinx-immaterial or Sphinx, try removing that workaround first. Notebooks in `docs/source/notebooks/` are rendered by nbsphinx. Dev notebooks in root `notebooks/` are ignored by pre-commit.
 - Package published to PyPI on tags via trusted publishing (no password needed).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,24 @@ Required packages include:
 
 ### Local Documentation Build
 
+**Prerequisites:**
+
+First, install documentation dependencies (one-time setup):
+```bash
+poetry run pip install -r docs/requirements.txt
+```
+
+This includes:
+- `sphinx` - Documentation builder
+- `sphinx-material` - Material theme
+- `sphinx-design` - Grid and card layouts for modern UI
+- `nbsphinx` - Jupyter notebook support
+- `sphinxcontrib-bibtex` - Bibliography support
+- `myst-parser` - Markdown support
+- Visualization libraries (bokeh, plotly, seaborn)
+
+**Building the Docs:**
+
 ```bash
 # Navigate to docs directory
 cd docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,376 @@
+# Mendeleev - Claude Code Assistant Guide
+
+## Project Overview
+
+**mendeleev** is a Pythonic periodic table of elements library that provides a convenient Python API for accessing various properties of elements, ions, and isotopes. It integrates with pandas for data access and offers visualization capabilities through bokeh, plotly, and seaborn.
+
+- **Repository**: https://github.com/lmmentel/mendeleev
+- **Documentation**: https://mendeleev.readthedocs.io
+- **License**: MIT
+- **Current Version**: 1.1.0
+
+## Technology Stack
+
+### Core Dependencies
+- **Python**: 3.9 - 3.13
+- **pandas**: Data manipulation and analysis (>=1.1.0)
+- **SQLAlchemy**: Database ORM and data models (>=1.4.0)
+- **pydantic**: Data validation and settings management (^2.9.2)
+- **pint**: Unit conversions and physical quantities (^0.24.4)
+- **numpy**: Numerical computing (^2.0)
+
+### Development Tools
+- **Poetry**: Dependency and environment management
+- **pytest**: Testing framework (with pytest-xdist and pytest-cov)
+- **Sphinx**: Documentation generation (with sphinx-material theme)
+- **pre-commit**: Git hooks for code quality
+- **ruff**: Linting and code formatting
+- **alembic**: Database migrations
+- **invoke**: Task automation
+
+### Optional Visualization Dependencies
+- **bokeh**: Interactive visualizations (^3.0)
+- **plotly**: Interactive plots (^5.0)
+- **seaborn**: Statistical visualizations (>=0.12)
+
+## Project Structure
+
+```
+mendeleev/
+├── mendeleev/           # Main package source code
+│   ├── __init__.py
+│   ├── models.py        # SQLAlchemy data models
+│   ├── fetch.py         # Data fetching utilities
+│   ├── db.py            # Database utilities
+│   ├── econf.py         # Electronic configuration
+│   ├── elements.db      # SQLite database with element data
+│   ├── cli.py           # Command-line interface
+│   ├── vis/             # Visualization modules
+│   │   ├── bokeh.py
+│   │   ├── plotly.py
+│   │   ├── seaborn.py
+│   │   └── utils.py
+│   └── interfaces/      # External data interfaces
+├── tests/               # Test suite
+│   ├── test_element.py
+│   ├── test_isotope.py
+│   ├── test_ion.py
+│   ├── test_fetch.py
+│   ├── test_vis.py
+│   └── test_econf/
+├── docs/                # Sphinx documentation
+│   ├── source/          # Documentation source files
+│   │   ├── conf.py      # Sphinx configuration
+│   │   ├── notebooks/   # Jupyter notebook tutorials
+│   │   └── api/         # API documentation
+│   ├── Makefile         # Documentation build commands
+│   └── build/           # Generated documentation
+├── notebooks/           # Development notebooks (not in docs)
+├── alembic/             # Database migration scripts
+│   └── versions/
+├── tasks.py             # Invoke task definitions
+├── pyproject.toml       # Poetry configuration and dependencies
+└── CONTRIBUTING.md      # Contribution guidelines
+```
+
+## Development Setup
+
+### Prerequisites
+- Python 3.9 or higher
+- [Poetry](https://python-poetry.org/) for dependency management
+- Git
+
+### Initial Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/lmmentel/mendeleev.git
+   cd mendeleev
+   ```
+
+2. **Install dependencies**
+   ```bash
+   # Install core dependencies
+   poetry install
+
+   # Install with visualization dependencies
+   poetry install --with vis
+   ```
+
+3. **Activate the virtual environment**
+   ```bash
+   poetry shell
+   ```
+
+## Running Tests
+
+### Basic Test Execution
+
+```bash
+# Run all tests
+poetry run pytest
+
+# Run tests with coverage report
+poetry run pytest --cov=mendeleev
+
+# Run tests in parallel (using pytest-xdist)
+poetry run pytest -n auto
+
+# Run tests with duration reporting (slowest 10 tests)
+poetry run pytest --durations=10
+```
+
+### Run Specific Tests
+
+```bash
+# Run tests in a specific file
+poetry run pytest tests/test_element.py
+
+# Run a specific test function
+poetry run pytest tests/test_element.py::test_function_name
+
+# Run tests matching a pattern
+poetry run pytest -k "element"
+```
+
+### Test Configuration
+
+Tests are configured in `pyproject.toml`:
+```toml
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "--durations=10 -n auto"
+```
+
+## Building Documentation
+
+### Local Documentation Build
+
+```bash
+# Navigate to docs directory
+cd docs
+
+# Build HTML documentation
+make html
+
+# View the documentation
+# Open docs/build/html/index.html in your browser
+```
+
+### Other Documentation Formats
+
+```bash
+# Build as single HTML page
+make singlehtml
+
+# Build PDF (requires LaTeX)
+make latexpdf
+
+# Check for broken links
+make linkcheck
+
+# Clean build artifacts
+make clean
+```
+
+### Rendering Data Documentation
+
+After updating the `PropertyMetadata` model, regenerate the data documentation:
+
+```bash
+# From project root
+inv render-data-docs
+
+# Then rebuild docs
+cd docs && make html
+```
+
+### Documentation Structure
+
+The documentation includes:
+- **Overview & Installation**: Getting started guides
+- **Tutorials**: Jupyter notebook tutorials covering key features
+- **Data Reference**: Complete property listings with units and citations
+- **Data Access**: How to fetch and query data
+- **Units**: Working with physical units (pint integration)
+- **Electronegativity**: Comprehensive guide to 15+ electronegativity scales
+- **FAQ**: Frequently asked questions
+- **Troubleshooting**: Common issues and solutions
+- **API Reference**: Complete API documentation
+- **Contributing Guide**: How to contribute to the project
+
+## Database Management
+
+The project uses SQLAlchemy with SQLite (`mendeleev/elements.db`) for data storage.
+
+### Creating Database Migrations
+
+When adding new models or modifying existing ones:
+
+```bash
+# Create a new migration
+alembic revision -m "Description of changes"
+
+# Apply migrations
+alembic upgrade head
+
+# Check migration status
+alembic current
+
+# Compare databases (against master branch)
+inv sqldiff
+```
+
+## Invoke Tasks
+
+The project includes custom invoke tasks defined in `tasks.py`:
+
+```bash
+# Export data to multiple formats (csv, json, html, markdown, sql)
+inv export
+
+# Render data documentation from PropertyMetadata
+inv render-data-docs
+
+# Compare database with master branch
+inv sqldiff
+
+# Time import performance
+inv timeimport
+```
+
+## Code Quality
+
+### Pre-commit Hooks
+
+The project uses pre-commit hooks for code quality:
+
+```bash
+# Install pre-commit hooks
+pre-commit install
+
+# Run hooks manually on all files
+pre-commit run --all-files
+
+# Run specific hook
+pre-commit run ruff --all-files
+```
+
+### Linting and Formatting
+
+The project uses **ruff** for both linting and formatting (configured via pre-commit).
+
+## Common Development Tasks
+
+### Adding a New Element Property
+
+1. Update the data model in `mendeleev/models.py`
+2. Create an alembic migration: `alembic revision -m "Add property X"`
+3. Implement migration logic in `alembic/versions/`
+4. Apply migration: `alembic upgrade head`
+5. Update `PropertyMetadata` table if needed
+6. Regenerate data docs: `inv render-data-docs`
+7. Add tests in appropriate test file
+8. Run tests: `poetry run pytest`
+
+### Working with the CLI
+
+The package provides a command-line tool:
+
+```bash
+# Get element information by symbol
+element.py Si
+
+# Get element by atomic number
+element.py 14
+
+# Get element by name
+element.py Silicon
+```
+
+## CI/CD Pipeline
+
+GitHub Actions workflow (`.github/workflows/main.yml`):
+- **Runs on**: Ubuntu, macOS, Windows
+- **Python versions**: 3.9, 3.10, 3.11, 3.12, 3.13
+- **Steps**:
+  1. Install dependencies with Poetry
+  2. Run pre-commit hooks (ruff linting)
+  3. Run pytest with coverage
+  4. Publish to PyPI on tagged releases
+
+## Key Data Models
+
+The project uses SQLAlchemy models (`mendeleev/models.py`):
+
+- **Element**: Main element properties and attributes
+- **Isotope**: Isotope-specific data
+- **Ion**: Ionic species data
+- **IonicRadius**: Ionic radii for different oxidation states
+- **IonizationEnergy**: Ionization energies
+- **OxidationState**: Oxidation states
+- **ScreeningConstant**: Nuclear screening constants
+- **PropertyMetadata**: Metadata about element properties
+
+## Important Files
+
+- **pyproject.toml**: Poetry configuration, dependencies, and tool settings
+- **tasks.py**: Invoke task definitions for common operations
+- **docs/source/conf.py**: Sphinx documentation configuration
+- **mendeleev/elements.db**: SQLite database with all element data
+- **.github/workflows/main.yml**: CI/CD pipeline configuration
+- **CONTRIBUTING.md**: Detailed contribution guidelines
+
+## Testing Strategy
+
+The test suite covers:
+- Element property access and validation
+- Isotope data and calculations
+- Ion charge states and properties
+- Electronic configuration parsing
+- Database queries and fetching
+- Visualization functions
+- CLI functionality
+
+## Useful Commands Summary
+
+```bash
+# Setup
+poetry install --with vis
+
+# Testing
+poetry run pytest --cov=mendeleev
+
+# Documentation
+cd docs && make html
+
+# Code quality
+pre-commit run --all-files
+
+# Database
+alembic upgrade head
+
+# Tasks
+inv render-data-docs
+inv export
+```
+
+## Resources
+
+- **Main Documentation**: https://mendeleev.readthedocs.io
+- **Interactive Tutorials**: Available as Jupyter notebooks on Binder
+- **API Reference**: https://mendeleev.readthedocs.io/en/stable/api/api.html
+- **Data Sources**: https://github.com/lmmentel/mendeleev-data
+- **Issues**: https://github.com/lmmentel/mendeleev/issues
+- **Discussions**: https://github.com/lmmentel/mendeleev/discussions
+
+## Notes for Claude Code
+
+- The database file `mendeleev/elements.db` is the core data store - handle with care
+- When modifying models, always create alembic migrations
+- Documentation notebooks in `docs/source/notebooks/` are part of the documentation
+- Development notebooks in root `notebooks/` are for experimentation
+- The project follows semantic versioning (currently v1.1.0)
+- All property metadata should include units, descriptions, and citations
+- Tests should pass on all supported Python versions (3.9-3.13)
+- Pre-commit hooks must pass before committing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,33 +144,56 @@ addopts = "--durations=10 -n auto"
 
 ## Building Documentation
 
+### Prerequisites
+
+Documentation requires additional dependencies beyond the core package:
+
+```bash
+# Install documentation dependencies (one-time setup)
+poetry run pip install -r docs/requirements.txt
+```
+
+Required packages include:
+- sphinx, nbsphinx (documentation generator)
+- sphinx-material (documentation theme)
+- myst-parser (Markdown support)
+- sphinxcontrib-bibtex (bibliography)
+- bokeh, plotly, seaborn (for visualization examples)
+- ipython, ipykernel (for notebook examples)
+
 ### Local Documentation Build
 
 ```bash
 # Navigate to docs directory
 cd docs
 
-# Build HTML documentation
-make html
+# Build HTML documentation using poetry
+poetry run make html
 
 # View the documentation
 # Open docs/build/html/index.html in your browser
 ```
 
+**Important Notes:**
+- Always use `poetry run make html` (not just `make html`)
+- First build may take longer as it processes all notebooks
+- Build produces warnings (572 warnings is normal)
+- Successfully built docs show: "build succeeded, 572 warnings"
+
 ### Other Documentation Formats
 
 ```bash
 # Build as single HTML page
-make singlehtml
+poetry run make singlehtml
 
 # Build PDF (requires LaTeX)
-make latexpdf
+poetry run make latexpdf
 
 # Check for broken links
-make linkcheck
+poetry run make linkcheck
 
 # Clean build artifacts
-make clean
+poetry run make clean
 ```
 
 ### Rendering Data Documentation
@@ -179,11 +202,35 @@ After updating the `PropertyMetadata` model, regenerate the data documentation:
 
 ```bash
 # From project root
-inv render-data-docs
+poetry run inv render-data-docs
 
 # Then rebuild docs
-cd docs && make html
+cd docs && poetry run make html
 ```
+
+### Documentation Build Troubleshooting
+
+**Issue: "sphinx-build command not found"**
+```bash
+# Install doc dependencies
+poetry run pip install -r docs/requirements.txt
+```
+
+**Issue: "No module named 'myst_parser'"**
+```bash
+# Ensure all doc dependencies are installed
+cd docs
+poetry run pip install -r requirements.txt
+```
+
+**Issue: "Build failed with SQLAlchemy errors"**
+- This should be fixed by the autodoc event handlers in `conf.py`
+- If you see `NotImplementedError: <built-in function getitem>`, the skip_hybrid_properties handler may need updating
+
+**Issue: "WARNING: duplicate object description"**
+- These are cosmetic warnings from autosummary
+- They don't prevent documentation from building
+- Safe to ignore
 
 ### Documentation Structure
 
@@ -196,6 +243,7 @@ The documentation includes:
 - **Electronegativity**: Comprehensive guide to 15+ electronegativity scales
 - **FAQ**: Frequently asked questions
 - **Troubleshooting**: Common issues and solutions
+- **API Overview**: Architecture, patterns, and decision guide
 - **API Reference**: Complete API documentation
 - **Contributing Guide**: How to contribute to the project
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,20 +180,26 @@ which should apply the changes to the ``mendeleev/elements.db`` database.
 Documentation is build with [Sphinx](https://www.sphinx-doc.org/en/master/) and [reStructuredText](https://docutils.sourceforge.io/rst.html). Once you [setup your local environment](#local-setup) you can build the documentation locally with:
 
 ```bash
+# Install documentation dependencies (one-time setup)
+poetry run pip install -r docs/requirements.txt
+
+# Build documentation
 cd docs
-make html
+poetry run make html
 ```
 
-Results and placed in ``build/_html`` and you can open ``build/_html/index.html`` with your favorite browser to see the results.
+Results are placed in ``build/html`` and you can open ``build/html/index.html`` with your favorite browser to see the results.
+
+**Note**: Always use `poetry run make html` to ensure the correct Python environment is used. The build will show warnings (this is normal) and should complete with "build succeeded, 572 warnings".
 
 Documentation of available [data points](https://mendeleev.readthedocs.io/en/stable/data.html) are require an extra step where metadata from
-the [PropertyMetadata](https://mendeleev.readthedocs.io/en/stable/api/models.html#propertymetadata) model is rendered into rst format  as ``docs/source/data.rst`` file. To generate an upadted version of ``data.rst`` after updating ``PropertyMetadata`` run:
+the [PropertyMetadata](https://mendeleev.readthedocs.io/en/stable/api/models.html#propertymetadata) model is rendered into rst format  as ``docs/source/data.rst`` file. To generate an updated version of ``data.rst`` after updating ``PropertyMetadata`` run:
 
 ```bash
-inv render-data-docs
+poetry run inv render-data-docs
 ```
 
-Inspect the ``data.rst`` file before committing to check that everyting looks correct.
+Inspect the ``data.rst`` file before committing to check that everything looks correct.
 
 ## Styleguides
 ### Commit Messages

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ of elements, ions and isotopes in the periodic table of elements.
 > - sql,
 > - markdown.
 >
-> All releases a tagged with the same version numbers as ``mendeeleev``.
+> All releases a tagged with the same version numbers as ``mendeleev``.
 
 <!-- TABLE OF CONTENTS -->
 ## Table of Contents
@@ -91,8 +91,9 @@ enables you to create customized periodic tables displaying various
 properties.
 
 ![peridic_table](docs/source/_static/img/mendeleev_periodic_series.png)
-Django Extensions is free and always will be. It is development and maintained by developers in an Open Source manner. Any support is welcome. You could help by writing documentation, pull-requests, report issues and/or translations.
-iodic trends in the periodic tables. If you want to
+
+The package also facilitates the exploration and visualization of
+periodic trends in the periodic table. If you want to
 look at some examples there are a few
 [tutorials](http://mendeleev.readthedocs.io/en/stable/tutorials.html)
 available as [jupyter notebooks](http://jupyter.org/).
@@ -141,6 +142,14 @@ pip install git+https://github.com/lmmentel/mendeleev.git
 ## Documentation
 
 Full documentation is hosted on [Read the Docs](http://mendeleev.readthedocs.org/en/latest/).
+
+**Key Documentation Pages:**
+- [API Overview](https://mendeleev.readthedocs.io/en/stable/api_overview.html) - Architecture and usage patterns
+- [Units Support](https://mendeleev.readthedocs.io/en/stable/units.html) - Working with physical units (v1.1.0+)
+- [FAQ](https://mendeleev.readthedocs.io/en/stable/faq.html) - Frequently asked questions
+- [Troubleshooting](https://mendeleev.readthedocs.io/en/stable/troubleshooting.html) - Common issues and solutions
+
+**Interactive Tutorials:**
 
 There are also tutorials available as [Jupyter](https://jupyter.org/)
 notebooks on [binder](https://mybinder.org/) where you can explore the examples interactively:
@@ -281,6 +290,13 @@ important entries are listed:
 - quadrupole moment
 - quadrupole moment uncertainty
 - spin
+
+### Units Support (v1.1.0+)
+
+Since version 1.1.0, mendeleev integrates with [pint](https://pint.readthedocs.io/) to provide
+physical units for properties. Each property includes metadata describing its units, making it easy
+to work with quantities in different unit systems and perform unit-aware calculations.
+See the [Units documentation](https://mendeleev.readthedocs.io/en/stable/units.html) for details.
 
 ## Getting started
 
@@ -545,7 +561,7 @@ or the older [BibTeX](http://www.bibtex.org/) format
 
 ``` {.sourceCode .latex}
 @misc{mendeleev2014,
-   auhor = {Mentel, Łukasz},
+   author = {Mentel, Łukasz},
    title = {mendeleev} -- A Python resource for properties of chemical elements, ions and isotopes, ver. 1.1.0},
    howpublished = {\url{https://github.com/lmmentel/mendeleev}},
    year  = {2014--},

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,6 +11,6 @@ sphinxcontrib-bibtex
 pybtex
 pybtex-docutils
 sphinx-copybutton
-sphinx-material
+sphinx-immaterial
 sphinx-issues
 sphinx-design

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ seaborn
 plotly
 ipython
 ipykernel
-sphinx
+sphinx>=8.0,<9.0
 nbsphinx
 sphinxcontrib-bibtex
 pybtex

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,3 +14,4 @@ sphinx-copybutton
 sphinx-immaterial
 sphinx-issues
 sphinx-design
+invoke

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,3 +13,4 @@ pybtex-docutils
 sphinx-copybutton
 sphinx-material
 sphinx-issues
+sphinx-design

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,4 @@
-bokeh
-jupyter_bokeh
 myst-parser
-seaborn
-plotly
 ipython
 ipykernel
 sphinx>=8.0,<9.0

--- a/docs/source/api/api.rst
+++ b/docs/source/api/api.rst
@@ -5,7 +5,11 @@ API Reference
 *************
 
 Here you'll find API documentation of the mendeleev's modules. For most users it'll be enough to use the high-level API provided by the classes below.
-For more advances use cases you can use the lower-level functions and classes across the modules.
+For more advanced use cases you can use the lower-level functions and classes across the modules.
+
+.. tip::
+   New to the API? Start with the :doc:`API Overview <../api_overview>` for architecture explanations,
+   usage patterns, and a decision guide to help you choose the right functions.
 
 .. toctree::
    :maxdepth: 2
@@ -13,19 +17,50 @@ For more advances use cases you can use the lower-level functions and classes ac
    Models <models>
 
 
-Modules
-=======
+Core Modules
+============
+
+High-level functions and classes for accessing element data.
 
 .. autosummary::
    :toctree:
 
-   mendeleev.cli
-   mendeleev.db
-   mendeleev.econf
-   mendeleev.electronegativity
-   mendeleev.fetch
    mendeleev.mendeleev
+   mendeleev.fetch
+   mendeleev.ion
+
+Data Models
+===========
+
+SQLAlchemy models representing chemical entities and properties.
+
+.. autosummary::
+   :toctree:
+
+   mendeleev.models
+
+Specialized Modules
+===================
+
+Modules for specific calculations and data processing.
+
+.. autosummary::
+   :toctree:
+
+   mendeleev.electronegativity
+   mendeleev.econf
+
+Utility Modules
+===============
+
+Database access and utility functions.
+
+.. autosummary::
+   :toctree:
+
+   mendeleev.db
    mendeleev.utils
+   mendeleev.cli
 
 
 Visualization

--- a/docs/source/api/mendeleev.electronegativity.rst
+++ b/docs/source/api/mendeleev.electronegativity.rst
@@ -7,7 +7,7 @@
    .. rubric:: Functions
 
    .. autosummary::
-
+   
       allred_rochow
       cottrell_sutton
       generic

--- a/docs/source/api/mendeleev.electronegativity.rst
+++ b/docs/source/api/mendeleev.electronegativity.rst
@@ -7,11 +7,12 @@
    .. rubric:: Functions
 
    .. autosummary::
-   
+
       allred_rochow
       cottrell_sutton
       generic
       gordy
+      interpolate_property
       li_xue
       martynov_batsanov
       mulliken

--- a/docs/source/api/mendeleev.ion.rst
+++ b/docs/source/api/mendeleev.ion.rst
@@ -1,0 +1,12 @@
+﻿mendeleev.ion
+=============
+
+.. automodule:: mendeleev.ion
+
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Ion
+   

--- a/docs/source/api/mendeleev.mendeleev.rst
+++ b/docs/source/api/mendeleev.mendeleev.rst
@@ -8,6 +8,7 @@
 
    .. autosummary::
    
+      _get_element
       deltaN
       element
       get_all_elements

--- a/docs/source/api/mendeleev.models.rst
+++ b/docs/source/api/mendeleev.models.rst
@@ -1,0 +1,55 @@
+mendeleev.models
+================
+
+.. automodule:: mendeleev.models
+
+   This module contains all the SQLAlchemy data models representing chemical entities
+   and their properties. These models map to tables in the SQLite database.
+
+   .. rubric:: Core Models
+
+   .. autosummary::
+      :toctree:
+
+      Element
+      Isotope
+      Ion
+
+   .. rubric:: Property Models
+
+   .. autosummary::
+      :toctree:
+
+      IonicRadius
+      IonizationEnergy
+      OxidationState
+      ScreeningConstant
+      ScatteringFactor
+      PhaseTransition
+
+   .. rubric:: Organization Models
+
+   .. autosummary::
+      :toctree:
+
+      Group
+      Series
+
+   .. rubric:: Metadata Models
+
+   .. autosummary::
+      :toctree:
+
+      PropertyMetadata
+
+   .. rubric:: Enumerations
+
+   .. autosummary::
+      :toctree:
+
+      ValueOrigin
+
+   .. note::
+      For detailed documentation of each model class, see :doc:`models`.
+      Most users will access these through :func:`mendeleev.element` or
+      :func:`mendeleev.fetch.fetch_table`.

--- a/docs/source/api/mendeleev.models.rst
+++ b/docs/source/api/mendeleev.models.rst
@@ -6,50 +6,10 @@ mendeleev.models
    This module contains all the SQLAlchemy data models representing chemical entities
    and their properties. These models map to tables in the SQLite database.
 
-   .. rubric:: Core Models
-
-   .. autosummary::
-      :toctree:
-
-      Element
-      Isotope
-      Ion
-
-   .. rubric:: Property Models
-
-   .. autosummary::
-      :toctree:
-
-      IonicRadius
-      IonizationEnergy
-      OxidationState
-      ScreeningConstant
-      ScatteringFactor
-      PhaseTransition
-
-   .. rubric:: Organization Models
-
-   .. autosummary::
-      :toctree:
-
-      Group
-      Series
-
-   .. rubric:: Metadata Models
-
-   .. autosummary::
-      :toctree:
-
-      PropertyMetadata
-
-   .. rubric:: Enumerations
-
-   .. autosummary::
-      :toctree:
-
-      ValueOrigin
-
    .. note::
       For detailed documentation of each model class, see :doc:`models`.
-      Most users will access these through :func:`mendeleev.element` or
+      Most users will access these through :func:`mendeleev.element() <mendeleev.mendeleev.element>` or
       :func:`mendeleev.fetch.fetch_table`.
+
+      The :class:`~mendeleev.ion.Ion` class is documented separately in
+      :doc:`mendeleev.ion` as it's not a SQLAlchemy model.

--- a/docs/source/api/mendeleev.models.rst
+++ b/docs/source/api/mendeleev.models.rst
@@ -1,15 +1,34 @@
-mendeleev.models
+﻿mendeleev.models
 ================
 
 .. automodule:: mendeleev.models
 
-   This module contains all the SQLAlchemy data models representing chemical entities
-   and their properties. These models map to tables in the SQLite database.
+   
+   .. rubric:: Functions
 
-   .. note::
-      For detailed documentation of each model class, see :doc:`models`.
-      Most users will access these through :func:`mendeleev.element() <mendeleev.mendeleev.element>` or
-      :func:`mendeleev.fetch.fetch_table`.
+   .. autosummary::
+   
+      fetch_by_group
+      fetch_unit_metadata
+      with_uncertainty
+   
+   .. rubric:: Classes
 
-      The :class:`~mendeleev.ion.Ion` class is documented separately in
-      :doc:`mendeleev.ion` as it's not a SQLAlchemy model.
+   .. autosummary::
+   
+      Element
+      Group
+      IonicRadius
+      IonizationEnergy
+      Isotope
+      IsotopeDecayMode
+      OxidationState
+      PhaseTransition
+      PropertyMetadata
+      ReprMixin
+      ScatteringFactor
+      ScreeningConstant
+      Series
+      UnitMixin
+      ValueOrigin
+   

--- a/docs/source/api_overview.rst
+++ b/docs/source/api_overview.rst
@@ -327,146 +327,37 @@ or :py:func:`fetch_table() <mendeleev.fetch.fetch_table>` instead.
 Common Usage Patterns
 ======================
 
-Pattern 1: Single Element Properties
--------------------------------------
+The :doc:`Quick Start guide <quick>` provides copy-paste examples for common
+tasks. This section summarizes which function to use for each use case.
 
-**Use case**: Get specific properties for one or a few elements.
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 50
 
-**Use**: :py:func:`element() <mendeleev.mendeleev.element>`
-
-::
-
-    from mendeleev import element
-
-    si = element('Si')
-    print(f"Atomic radius: {si.atomic_radius} pm")
-    print(f"Electronegativity: {si.en_pauling}")
-    print(f"Melting point: {si.melting_point} K")
-
-Pattern 2: Bulk Data Analysis
-------------------------------
-
-**Use case**: Analyze properties across many elements.
-
-**Use**: :py:func:`fetch_table() <mendeleev.fetch.fetch_table>`
-
-::
-
-    from mendeleev import fetch_table
-    import matplotlib.pyplot as plt
-
-    # Get all elements
-    df = fetch_table('elements')
-
-    # Analyze trends
-    metals = df[df['block'].isin(['s', 'd', 'f'])]
-
-    # Plot
-    plt.scatter(metals['atomic_number'], metals['density'])
-    plt.xlabel('Atomic Number')
-    plt.ylabel('Density (g/cm³)')
-    plt.show()
-
-Pattern 3: Isotope Information
--------------------------------
-
-**Use case**: Get isotope data for an element.
-
-**Method 1**: Via element object
-
-::
-
-    from mendeleev import element
-
-    carbon = element('C')
-    for iso in carbon.isotopes:
-        print(f"C-{iso.mass_number}: {iso.abundance}%")
-
-**Method 2**: Direct isotope access
-
-::
-
-    from mendeleev import isotope
-
-    c14 = isotope('C', 14)
-    print(f"Half-life: {c14.half_life} years")
-
-Pattern 4: Ion Properties
---------------------------
-
-**Use case**: Work with ionic species.
-
-**Use**: :py:class:`Ion <mendeleev.ion.Ion>` class
-
-::
-
-    from mendeleev.ion import Ion
-
-    fe2 = Ion('Fe', charge=2)
-    fe3 = Ion('Fe', charge=3)
-
-    print(f"Fe²⁺ ionic radius: {fe2.ionic_radius} pm")
-    print(f"Fe³⁺ ionic radius: {fe3.ionic_radius} pm")
-
-Pattern 5: Visualization
--------------------------
-
-**Use case**: Create periodic table visualizations.
-
-**Use**: :py:func:`periodic_table() <mendeleev.vis.periodictable.periodic_table>`
-
-::
-
-    from mendeleev.vis import periodic_table
-
-    # Interactive plot with plotly
-    periodic_table(
-        colorby='atomic_radius',
-        title='Atomic Radii',
-        backend='plotly'
-    )
-
-    # Static plot with seaborn
-    periodic_table(
-        colorby='electronegativity_pauling',
-        backend='seaborn',
-        output='en_plot.png'
-    )
-
-Pattern 6: Electronegativity Comparison
-----------------------------------------
-
-**Use case**: Compare multiple electronegativity scales.
-
-**Use**: :py:func:`fetch_electronegativities() <mendeleev.fetch.fetch_electronegativities>`
-
-::
-
-    from mendeleev import fetch_electronegativities
-
-    # Get specific scales
-    en_df = fetch_electronegativities(['pauling', 'allen', 'mulliken'])
-
-    # Compare for specific element
-    si_en = en_df[en_df['symbol'] == 'Si']
-    print(si_en)
-
-Pattern 7: Property Metadata Lookup
-------------------------------------
-
-**Use case**: Find units, sources, and citations for properties.
-
-**Use**: :py:class:`PropertyMetadata <mendeleev.models.PropertyMetadata>`
-
-::
-
-    from mendeleev import fetch_table
-
-    metadata = fetch_table('propertymetadata')
-
-    # Find properties with energy units
-    energy_props = metadata[metadata['unit'].str.contains('eV', na=False)]
-    print(energy_props[['attribute_name', 'unit', 'citation_keys']])
+   * - Use case
+     - Function
+     - See also
+   * - Get properties for one element
+     - ``element()``
+     - :doc:`quick`
+   * - Bulk data across all elements
+     - ``fetch_table()``
+     - :doc:`quick`
+   * - Isotope data
+     - ``isotope()`` / ``.isotopes``
+     - :doc:`quick`
+   * - Ion properties
+     - ``Ion()``
+     - :doc:`quick`
+   * - Periodic table plots
+     - ``periodic_table()``
+     - :doc:`tutorials`
+   * - Electronegativity comparison
+     - ``fetch_electronegativities()``
+     - :doc:`electronegativity`
+   * - Property metadata lookup
+     - ``fetch_table('propertymetadata')``
+     - :doc:`data_access`
 
 
 Type Hints

--- a/docs/source/api_overview.rst
+++ b/docs/source/api_overview.rst
@@ -1,0 +1,552 @@
+.. _api-overview:
+
+************
+API Overview
+************
+
+This page provides a high-level overview of the mendeleev API, explaining the main components,
+common usage patterns, and how to choose the right function or class for your needs.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+Architecture
+============
+
+The mendeleev package is organized into several layers:
+
+.. code-block:: text
+
+    User-Facing API
+    ├── Element Access (element, isotope)
+    ├── Bulk Data (fetch_table, fetch_*)
+    └── Visualization (periodic_table)
+         │
+    Data Models
+    ├── Element, Isotope, Ion
+    ├── IonicRadius, IonizationEnergy
+    └── Other property classes
+         │
+    Database Layer
+    └── SQLite database (elements.db)
+
+Main Components
+===============
+
+1. Element Access Functions
+----------------------------
+
+High-level functions for accessing individual elements and isotopes.
+
+:py:func:`element <mendeleev.mendeleev.element>`
+    Primary function for getting element data by symbol, name, or atomic number.
+    **Use this** for most element access needs.
+
+:py:func:`isotope <mendeleev.mendeleev.isotope>`
+    Get specific isotope data by element and mass number.
+
+:py:func:`get_all_elements <mendeleev.mendeleev.get_all_elements>`
+    Get a list of all elements. **Note**: For data analysis, use :py:func:`fetch_table <mendeleev.fetch.fetch_table>` instead.
+
+**Example**::
+
+    from mendeleev import element
+
+    # Get silicon by symbol
+    si = element('Si')
+    print(si.atomic_radius)  # 132
+
+    # Get multiple elements
+    c, h, o = element(['C', 'H', 'O'])
+
+2. Data Fetching Functions
+---------------------------
+
+Functions for bulk data access, returning pandas DataFrames.
+
+:py:func:`fetch_table <mendeleev.fetch.fetch_table>`
+    Fetch any database table as a DataFrame. **Most versatile** bulk access function.
+    Available tables: ``elements``, ``isotopes``, ``ionicradii``, ``ionizationenergies``,
+    ``oxidationstates``, ``screeningconstants``, ``series``, ``groups``, ``propertymetadata``.
+
+:py:func:`fetch_electronegativities <mendeleev.fetch.fetch_electronegativities>`
+    Get electronegativity data across multiple scales.
+
+:py:func:`fetch_ionization_energies <mendeleev.fetch.fetch_ionization_energies>`
+    Get ionization energy data for specific degrees.
+
+:py:func:`fetch_ionic_radii <mendeleev.fetch.fetch_ionic_radii>`
+    Get ionic radii data with different radius types.
+
+**Example**::
+
+    from mendeleev import fetch_table
+
+    # Get all elements as DataFrame
+    elements = fetch_table('elements')
+
+    # Filter and analyze
+    noble_gases = elements[elements['group_id'] == 18]
+    print(noble_gases[['symbol', 'name', 'boiling_point']])
+
+3. Data Models
+--------------
+
+Object-oriented representations of chemical entities and properties.
+
+**Core Models:**
+
+:py:class:`Element <mendeleev.models.Element>`
+    The main element class with 80+ properties and methods.
+    Access via :py:func:`element() <mendeleev.mendeleev.element>`.
+
+:py:class:`Isotope <mendeleev.models.Isotope>`
+    Isotope data including mass, abundance, half-life, and decay modes.
+    Access via :py:func:`isotope() <mendeleev.mendeleev.isotope>` or ``element.isotopes``.
+
+:py:class:`Ion <mendeleev.ion.Ion>`
+    Ionic species with charge-dependent properties.
+    Create with ``Ion('Fe', charge=2)``.
+
+**Property Models:**
+
+:py:class:`IonicRadius <mendeleev.models.IonicRadius>`
+    Ionic radii for different oxidation states and coordination numbers.
+
+:py:class:`IonizationEnergy <mendeleev.models.IonizationEnergy>`
+    Successive ionization energies.
+
+:py:class:`OxidationState <mendeleev.models.OxidationState>`
+    Possible oxidation states for elements.
+
+:py:class:`PropertyMetadata <mendeleev.models.PropertyMetadata>`
+    Metadata about properties including units, sources, and citations.
+
+4. Visualization Functions
+---------------------------
+
+Functions for creating interactive periodic table visualizations.
+
+:py:func:`periodic_table <mendeleev.vis.periodictable.periodic_table>`
+    Main function for creating customizable periodic tables.
+    Supports multiple backends: bokeh, plotly, seaborn.
+
+**Backends:**
+
+- :py:mod:`mendeleev.vis.bokeh` - Interactive Bokeh visualizations
+- :py:mod:`mendeleev.vis.plotly` - Interactive Plotly visualizations
+- :py:mod:`mendeleev.vis.seaborn` - Static matplotlib/seaborn visualizations
+
+**Example**::
+
+    from mendeleev.vis import periodic_table
+
+    # Create interactive periodic table colored by property
+    periodic_table(colorby='atomic_radius', backend='plotly')
+
+5. Electronegativity Functions
+-------------------------------
+
+Functions for computing various electronegativity scales.
+
+:py:mod:`mendeleev.electronegativity`
+    Module containing functions for 15+ electronegativity scales:
+
+    - **Stored scales**: Access via ``element.en_pauling``, ``element.en_allen``, etc.
+    - **Computed scales**: Functions like :py:func:`mulliken() <mendeleev.electronegativity.mulliken>`,
+      :py:func:`sanderson() <mendeleev.electronegativity.sanderson>`, etc.
+
+See :doc:`electronegativity` for detailed scale descriptions.
+
+6. Database Functions
+---------------------
+
+Low-level database access (advanced users).
+
+:py:func:`get_session <mendeleev.db.get_session>`
+    Get SQLAlchemy session for direct database queries.
+
+:py:func:`get_engine <mendeleev.db.get_engine>`
+    Get SQLAlchemy engine.
+
+**Note**: Most users should use :py:func:`element() <mendeleev.mendeleev.element>`
+or :py:func:`fetch_table() <mendeleev.fetch.fetch_table>` instead.
+
+Common Usage Patterns
+======================
+
+Pattern 1: Single Element Properties
+-------------------------------------
+
+**Use case**: Get specific properties for one or a few elements.
+
+**Use**: :py:func:`element() <mendeleev.mendeleev.element>`
+
+::
+
+    from mendeleev import element
+
+    si = element('Si')
+    print(f"Atomic radius: {si.atomic_radius} pm")
+    print(f"Electronegativity: {si.en_pauling}")
+    print(f"Melting point: {si.melting_point} K")
+
+Pattern 2: Bulk Data Analysis
+------------------------------
+
+**Use case**: Analyze properties across many elements.
+
+**Use**: :py:func:`fetch_table() <mendeleev.fetch.fetch_table>`
+
+::
+
+    from mendeleev import fetch_table
+    import matplotlib.pyplot as plt
+
+    # Get all elements
+    df = fetch_table('elements')
+
+    # Analyze trends
+    metals = df[df['block'].isin(['s', 'd', 'f'])]
+
+    # Plot
+    plt.scatter(metals['atomic_number'], metals['density'])
+    plt.xlabel('Atomic Number')
+    plt.ylabel('Density (g/cm³)')
+    plt.show()
+
+Pattern 3: Isotope Information
+-------------------------------
+
+**Use case**: Get isotope data for an element.
+
+**Method 1**: Via element object
+
+::
+
+    from mendeleev import element
+
+    carbon = element('C')
+    for iso in carbon.isotopes:
+        print(f"C-{iso.mass_number}: {iso.abundance}%")
+
+**Method 2**: Direct isotope access
+
+::
+
+    from mendeleev import isotope
+
+    c14 = isotope('C', 14)
+    print(f"Half-life: {c14.half_life} years")
+
+Pattern 4: Ion Properties
+--------------------------
+
+**Use case**: Work with ionic species.
+
+**Use**: :py:class:`Ion <mendeleev.ion.Ion>` class
+
+::
+
+    from mendeleev.ion import Ion
+
+    fe2 = Ion('Fe', charge=2)
+    fe3 = Ion('Fe', charge=3)
+
+    print(f"Fe²⁺ ionic radius: {fe2.ionic_radius} pm")
+    print(f"Fe³⁺ ionic radius: {fe3.ionic_radius} pm")
+
+Pattern 5: Visualization
+-------------------------
+
+**Use case**: Create periodic table visualizations.
+
+**Use**: :py:func:`periodic_table() <mendeleev.vis.periodictable.periodic_table>`
+
+::
+
+    from mendeleev.vis import periodic_table
+
+    # Interactive plot with plotly
+    periodic_table(
+        colorby='atomic_radius',
+        title='Atomic Radii',
+        backend='plotly'
+    )
+
+    # Static plot with seaborn
+    periodic_table(
+        colorby='electronegativity_pauling',
+        backend='seaborn',
+        output='en_plot.png'
+    )
+
+Pattern 6: Electronegativity Comparison
+----------------------------------------
+
+**Use case**: Compare multiple electronegativity scales.
+
+**Use**: :py:func:`fetch_electronegativities() <mendeleev.fetch.fetch_electronegativities>`
+
+::
+
+    from mendeleev import fetch_electronegativities
+
+    # Get specific scales
+    en_df = fetch_electronegativities(['pauling', 'allen', 'mulliken'])
+
+    # Compare for specific element
+    si_en = en_df[en_df['symbol'] == 'Si']
+    print(si_en)
+
+Pattern 7: Property Metadata Lookup
+------------------------------------
+
+**Use case**: Find units, sources, and citations for properties.
+
+**Use**: :py:class:`PropertyMetadata <mendeleev.models.PropertyMetadata>`
+
+::
+
+    from mendeleev import fetch_table
+
+    metadata = fetch_table('propertymetadata')
+
+    # Find properties with energy units
+    energy_props = metadata[metadata['unit'].str.contains('eV', na=False)]
+    print(energy_props[['attribute_name', 'unit', 'citation_keys']])
+
+Decision Guide
+==============
+
+Use this flowchart to choose the right API component:
+
+.. code-block:: text
+
+    What do you want to do?
+    │
+    ├─ Get data for ONE element
+    │  └─> Use element('Symbol')
+    │
+    ├─ Get data for MANY elements
+    │  └─> Use fetch_table('elements')
+    │
+    ├─ Get isotope data
+    │  ├─ For one isotope
+    │  │  └─> Use isotope('Symbol', mass_number)
+    │  └─ For all isotopes of element
+    │     └─> Use element('Symbol').isotopes
+    │
+    ├─ Work with ions
+    │  └─> Use Ion('Symbol', charge=N)
+    │
+    ├─ Create visualizations
+    │  └─> Use periodic_table(...)
+    │
+    ├─ Compare electronegativity scales
+    │  └─> Use fetch_electronegativities([scales])
+    │
+    └─ Direct database queries
+       └─> Use get_session() (advanced)
+
+Quick Reference
+===============
+
+Most Common Functions
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 50 20
+
+   * - Function
+     - Purpose
+     - Returns
+   * - ``element(id)``
+     - Get element by symbol/name/number
+     - Element
+   * - ``fetch_table(name)``
+     - Get database table as DataFrame
+     - DataFrame
+   * - ``isotope(el, mass)``
+     - Get specific isotope
+     - Isotope
+   * - ``periodic_table(...)``
+     - Create visualization
+     - Plot/Figure
+   * - ``Ion(el, charge)``
+     - Create ionic species
+     - Ion
+
+Most Useful Element Properties
+-------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 20 20
+
+   * - Property
+     - Description
+     - Unit
+     - Example
+   * - ``atomic_number``
+     - Atomic number
+     - —
+     - ``14``
+   * - ``atomic_weight``
+     - Atomic weight
+     - Da
+     - ``28.085``
+   * - ``atomic_radius``
+     - Atomic radius (Slater)
+     - pm
+     - ``132``
+   * - ``electronegativity_pauling``
+     - Pauling electronegativity
+     - —
+     - ``1.9``
+   * - ``electron_affinity``
+     - Electron affinity
+     - eV
+     - ``1.39``
+   * - ``ionization_energies``
+     - Ionization energies
+     - eV
+     - ``[8.15, ...]``
+   * - ``melting_point``
+     - Melting point
+     - K
+     - ``1683``
+   * - ``boiling_point``
+     - Boiling point
+     - K
+     - ``2628``
+   * - ``density``
+     - Density at 295K
+     - g/cm³
+     - ``2.33``
+   * - ``isotopes``
+     - List of isotopes
+     - —
+     - ``[Isotope, ...]``
+
+Available Database Tables
+-------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Table Name
+     - Contents
+   * - ``elements``
+     - All element data (main table)
+   * - ``isotopes``
+     - Isotope data with masses, abundances, half-lives
+   * - ``ionicradii``
+     - Ionic radii for various oxidation states
+   * - ``ionizationenergies``
+     - Successive ionization energies
+   * - ``oxidationstates``
+     - Possible oxidation states
+   * - ``screeningconstants``
+     - Nuclear screening constants
+   * - ``groups``
+     - Periodic table group information
+   * - ``series``
+     - Element series (alkali metals, noble gases, etc.)
+   * - ``propertymetadata``
+     - Metadata about properties (units, sources, citations)
+   * - ``isotopedecaymodes``
+     - Isotope decay modes and branching ratios
+   * - ``phasetransitions``
+     - Phase transition data
+   * - ``scattering_factors``
+     - X-ray and neutron scattering factors
+
+Type Hints
+==========
+
+The mendeleev API uses type hints extensively. Here are the main types:
+
+.. code-block:: python
+
+    from typing import Union, List
+    from mendeleev.models import Element, Isotope
+    from mendeleev.ion import Ion
+    import pandas as pd
+
+    # Element access
+    element(ids: Union[int, str]) -> Element
+    element(ids: Union[List, Tuple]) -> List[Element]
+
+    # Isotope access
+    isotope(symbol_or_atn: Union[str, int], mass_number: int) -> Isotope
+
+    # Bulk data
+    fetch_table(table: str) -> pd.DataFrame
+
+    # Ions
+    Ion(label: Union[str, int], charge: int) -> Ion
+
+Error Handling
+==============
+
+Common exceptions and how to handle them:
+
+**ValueError: Element not found**
+
+::
+
+    from mendeleev import element
+
+    try:
+        el = element('Unobtanium')
+    except ValueError as e:
+        print(f"Element not found: {e}")
+
+**ValueError: Invalid charge for ion**
+
+::
+
+    from mendeleev.ion import Ion
+
+    try:
+        # Charge too large
+        ion = Ion('H', charge=5)
+    except ValueError as e:
+        print(f"Invalid charge: {e}")
+
+**NoResultFound: Isotope not found**
+
+::
+
+    from mendeleev import isotope
+    from sqlalchemy.exc import NoResultFound
+
+    try:
+        # Non-existent isotope
+        iso = isotope('C', 999)
+    except NoResultFound:
+        print("Isotope not found")
+
+See Also
+========
+
+- :doc:`data_access` - Detailed guide on accessing data
+- :doc:`data` - Complete property reference
+- :doc:`tutorials` - Step-by-step tutorials
+- :doc:`api/api` - Complete API reference
+- :doc:`troubleshooting` - Common issues and solutions
+
+Next Steps
+==========
+
+**New Users**: Start with the :doc:`quick start guide <quick>` and :doc:`tutorials <tutorials>`.
+
+**Data Analysis**: Learn about :doc:`bulk data access <notebooks/bulk_data_access>`.
+
+**Visualization**: Explore :doc:`visualization tutorials <notebooks/visualizations>`.
+
+**Advanced**: Read the full :doc:`API Reference <api/api>`.

--- a/docs/source/api_overview.rst
+++ b/docs/source/api_overview.rst
@@ -4,12 +4,161 @@
 API Overview
 ************
 
-This page provides a high-level overview of the mendeleev API, explaining the main components,
-common usage patterns, and how to choose the right function or class for your needs.
+This page helps you choose the right function or class for your task, explains the
+main components, and shows common usage patterns.
 
 .. contents:: On this page
    :local:
    :depth: 2
+
+
+Decision Guide
+==============
+
+.. code-block:: text
+
+    What do you want to do?
+    │
+    ├─ Get data for ONE element
+    │  └─> Use element('Symbol')
+    │
+    ├─ Get data for MANY elements
+    │  └─> Use fetch_table('elements')
+    │
+    ├─ Get isotope data
+    │  ├─ For one isotope
+    │  │  └─> Use isotope('Symbol', mass_number)
+    │  └─ For all isotopes of element
+    │     └─> Use element('Symbol').isotopes
+    │
+    ├─ Work with ions
+    │  └─> Use Ion('Symbol', charge=N)
+    │
+    ├─ Create visualizations
+    │  └─> Use periodic_table(...)
+    │
+    ├─ Compare electronegativity scales
+    │  └─> Use fetch_electronegativities([scales])
+    │
+    └─ Direct database queries
+       └─> Use get_session() (advanced)
+
+
+Quick Reference
+===============
+
+Most Common Functions
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 50 20
+
+   * - Function
+     - Purpose
+     - Returns
+   * - ``element(id)``
+     - Get element by symbol/name/number
+     - Element
+   * - ``fetch_table(name)``
+     - Get database table as DataFrame
+     - DataFrame
+   * - ``isotope(el, mass)``
+     - Get specific isotope
+     - Isotope
+   * - ``periodic_table(...)``
+     - Create visualization
+     - Plot/Figure
+   * - ``Ion(el, charge)``
+     - Create ionic species
+     - Ion
+
+Most Useful Element Properties
+-------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 20 20
+
+   * - Property
+     - Description
+     - Unit
+     - Example
+   * - ``atomic_number``
+     - Atomic number
+     - —
+     - ``14``
+   * - ``atomic_weight``
+     - Atomic weight
+     - Da
+     - ``28.085``
+   * - ``atomic_radius``
+     - Atomic radius (Slater)
+     - pm
+     - ``132``
+   * - ``electronegativity_pauling``
+     - Pauling electronegativity
+     - —
+     - ``1.9``
+   * - ``electron_affinity``
+     - Electron affinity
+     - eV
+     - ``1.39``
+   * - ``ionization_energies``
+     - Ionization energies
+     - eV
+     - ``[8.15, ...]``
+   * - ``melting_point``
+     - Melting point
+     - K
+     - ``1683``
+   * - ``boiling_point``
+     - Boiling point
+     - K
+     - ``2628``
+   * - ``density``
+     - Density at 295K
+     - g/cm³
+     - ``2.33``
+   * - ``isotopes``
+     - List of isotopes
+     - —
+     - ``[Isotope, ...]``
+
+Available Database Tables
+-------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Table Name
+     - Contents
+   * - ``elements``
+     - All element data (main table)
+   * - ``isotopes``
+     - Isotope data with masses, abundances, half-lives
+   * - ``ionicradii``
+     - Ionic radii for various oxidation states
+   * - ``ionizationenergies``
+     - Successive ionization energies
+   * - ``oxidationstates``
+     - Possible oxidation states
+   * - ``screeningconstants``
+     - Nuclear screening constants
+   * - ``groups``
+     - Periodic table group information
+   * - ``series``
+     - Element series (alkali metals, noble gases, etc.)
+   * - ``propertymetadata``
+     - Metadata about properties (units, sources, citations)
+   * - ``isotopedecaymodes``
+     - Isotope decay modes and branching ratios
+   * - ``phasetransitions``
+     - Phase transition data
+   * - ``scattering_factors``
+     - X-ray and neutron scattering factors
+
 
 Architecture
 ============
@@ -30,6 +179,7 @@ The mendeleev package is organized into several layers:
          │
     Database Layer
     └── SQLite database (elements.db)
+
 
 Main Components
 ===============
@@ -172,6 +322,7 @@ Low-level database access (advanced users).
 
 **Note**: Most users should use :py:func:`element() <mendeleev.mendeleev.element>`
 or :py:func:`fetch_table() <mendeleev.fetch.fetch_table>` instead.
+
 
 Common Usage Patterns
 ======================
@@ -317,153 +468,6 @@ Pattern 7: Property Metadata Lookup
     energy_props = metadata[metadata['unit'].str.contains('eV', na=False)]
     print(energy_props[['attribute_name', 'unit', 'citation_keys']])
 
-Decision Guide
-==============
-
-Use this flowchart to choose the right API component:
-
-.. code-block:: text
-
-    What do you want to do?
-    │
-    ├─ Get data for ONE element
-    │  └─> Use element('Symbol')
-    │
-    ├─ Get data for MANY elements
-    │  └─> Use fetch_table('elements')
-    │
-    ├─ Get isotope data
-    │  ├─ For one isotope
-    │  │  └─> Use isotope('Symbol', mass_number)
-    │  └─ For all isotopes of element
-    │     └─> Use element('Symbol').isotopes
-    │
-    ├─ Work with ions
-    │  └─> Use Ion('Symbol', charge=N)
-    │
-    ├─ Create visualizations
-    │  └─> Use periodic_table(...)
-    │
-    ├─ Compare electronegativity scales
-    │  └─> Use fetch_electronegativities([scales])
-    │
-    └─ Direct database queries
-       └─> Use get_session() (advanced)
-
-Quick Reference
-===============
-
-Most Common Functions
----------------------
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 50 20
-
-   * - Function
-     - Purpose
-     - Returns
-   * - ``element(id)``
-     - Get element by symbol/name/number
-     - Element
-   * - ``fetch_table(name)``
-     - Get database table as DataFrame
-     - DataFrame
-   * - ``isotope(el, mass)``
-     - Get specific isotope
-     - Isotope
-   * - ``periodic_table(...)``
-     - Create visualization
-     - Plot/Figure
-   * - ``Ion(el, charge)``
-     - Create ionic species
-     - Ion
-
-Most Useful Element Properties
--------------------------------
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 35 20 20
-
-   * - Property
-     - Description
-     - Unit
-     - Example
-   * - ``atomic_number``
-     - Atomic number
-     - —
-     - ``14``
-   * - ``atomic_weight``
-     - Atomic weight
-     - Da
-     - ``28.085``
-   * - ``atomic_radius``
-     - Atomic radius (Slater)
-     - pm
-     - ``132``
-   * - ``electronegativity_pauling``
-     - Pauling electronegativity
-     - —
-     - ``1.9``
-   * - ``electron_affinity``
-     - Electron affinity
-     - eV
-     - ``1.39``
-   * - ``ionization_energies``
-     - Ionization energies
-     - eV
-     - ``[8.15, ...]``
-   * - ``melting_point``
-     - Melting point
-     - K
-     - ``1683``
-   * - ``boiling_point``
-     - Boiling point
-     - K
-     - ``2628``
-   * - ``density``
-     - Density at 295K
-     - g/cm³
-     - ``2.33``
-   * - ``isotopes``
-     - List of isotopes
-     - —
-     - ``[Isotope, ...]``
-
-Available Database Tables
--------------------------
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 70
-
-   * - Table Name
-     - Contents
-   * - ``elements``
-     - All element data (main table)
-   * - ``isotopes``
-     - Isotope data with masses, abundances, half-lives
-   * - ``ionicradii``
-     - Ionic radii for various oxidation states
-   * - ``ionizationenergies``
-     - Successive ionization energies
-   * - ``oxidationstates``
-     - Possible oxidation states
-   * - ``screeningconstants``
-     - Nuclear screening constants
-   * - ``groups``
-     - Periodic table group information
-   * - ``series``
-     - Element series (alkali metals, noble gases, etc.)
-   * - ``propertymetadata``
-     - Metadata about properties (units, sources, citations)
-   * - ``isotopedecaymodes``
-     - Isotope decay modes and branching ratios
-   * - ``phasetransitions``
-     - Phase transition data
-   * - ``scattering_factors``
-     - X-ray and neutron scattering factors
 
 Type Hints
 ==========
@@ -489,6 +493,7 @@ The mendeleev API uses type hints extensively. Here are the main types:
 
     # Ions
     Ion(label: Union[str, int], charge: int) -> Ion
+
 
 Error Handling
 ==============
@@ -530,6 +535,7 @@ Common exceptions and how to handle them:
         iso = isotope('C', 999)
     except NoResultFound:
         print("Isotope not found")
+
 
 See Also
 ========

--- a/docs/source/citing.rst
+++ b/docs/source/citing.rst
@@ -1,0 +1,53 @@
+.. _citing:
+
+*******
+Citing
+*******
+
+If you use mendeleev in a scientific publication, please cite:
+
+   L. M. Mentel, *mendeleev* - A Python resource for properties of chemical
+   elements, ions and isotopes. , 2014-- . DOI:
+   `10.5281/zenodo.204296088 <https://doi.org/10.5281/zenodo.204296088>`_.
+   Available at: https://github.com/lmmentel/mendeleev
+
+BibLaTeX
+========
+
+.. code-block:: latex
+
+   @software{mendeleev,
+      author = {Mentel, Łukasz},
+      title = {{mendeleev} -- A Python resource for properties of chemical
+               elements, ions and isotopes},
+      url = {https://github.com/lmmentel/mendeleev},
+      date = {2014--},
+  }
+
+BibTeX
+======
+
+.. code-block:: latex
+
+   @misc{mendeleev,
+      author = {Mentel, Łukasz},
+      title = {mendeleev -- A Python resource for properties of chemical
+               elements, ions and isotopes},
+      howpublished = {\url{https://github.com/lmmentel/mendeleev}},
+      year  = {2014--},
+   }
+
+Related projects
+================
+
+`periodictable <https://github.com/pkienzle/periodictable>`_
+    Periodic table with mass, density and xray/neutron scattering information.
+
+`periodic <https://github.com/luisnaranjo733/periodic>`_
+    Simple Python API / CLI for the periodic table.
+
+Funding
+=======
+
+This project is supported by the RCN (The Research Council of Norway) project
+number 239193.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,8 +69,6 @@ extensions = [
     "sphinxcontrib.bibtex",
 ]
 
-nbsphinx_allow_errors = True
-
 # sphinxcontrib.bibtex settings
 bibtex_bibfiles = ["references.bib"]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,7 @@ html_theme_options = {
     # If False, expand all TOC entries
     "globaltoc_collapse": True,
     # If True, show hidden TOC entries
-    "globaltoc_includehidden": False,
+    "globaltoc_includehidden": True,
     "heroes": {},
     "nav_links": [],
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,7 @@ autosummary_generate = True
 extensions = [
     "myst_parser",
     "sphinx_copybutton",
+    "sphinx_design",
     "sphinx_issues",  # linking github issues, prs, users
     "sphinx_material",
     "nbsphinx",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,6 @@ autodoc_mock_imports = [
     "pandas",
     "scipy",
     "seaborn",
-    "sqlalchemy",
 ]
 
 sys.path.append(str(Path("_ext").resolve()))
@@ -332,3 +331,27 @@ mathjax2_config = {
         "processClass": "math|output_area",
     }
 }
+
+
+# -- Autodoc event handlers ----------------------------------------------------
+
+
+def skip_hybrid_properties(app, what, name, obj, skip, options):
+    """
+    Skip SQLAlchemy hybrid properties that cause issues during autodoc.
+
+    These properties use SQLAlchemy's hybrid_property decorator which doesn't
+    work well with Sphinx's autodoc introspection during documentation generation.
+    """
+    from sqlalchemy.ext.hybrid import hybrid_property
+
+    # Skip all hybrid properties to avoid SQLAlchemy introspection errors
+    if isinstance(obj, hybrid_property):
+        return True
+
+    return skip
+
+
+def setup(app):
+    """Sphinx setup hook."""
+    app.connect("autodoc-skip-member", skip_hybrid_properties)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,8 +11,8 @@
 import inspect
 import os
 import sys
+import re
 from pathlib import Path
-import sphinx_material
 
 
 autodoc_mock_imports = [
@@ -54,7 +54,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_issues",  # linking github issues, prs, users
-    "sphinx_material",
+    "sphinx_immaterial",
     "nbsphinx",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
@@ -72,39 +72,55 @@ extensions = [
 bibtex_bibfiles = ["references.bib"]
 
 html_show_sourcelink = True
-html_sidebars = {
-    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
-}
 
-# Required theme setup
-extensions.append("sphinx_material")
-html_theme = "sphinx_material"
-html_theme_path = sphinx_material.html_theme_path()
-html_context = sphinx_material.get_html_context()
+html_theme = "sphinx_immaterial"
 
-# Material theme options (see theme.conf for more information)
+# Disable synopses to work around sphinx-immaterial KeyError:
+# py.data["synopses"] not initialized before after_content runs.
+object_description_options = [
+    (re.compile(".*"), {"generate_synopses": None}),
+]
+
 html_theme_options = {
-    # Set the name of the project to appear in the navigation.
-    "nav_title": "mendeleev",
-    # Set you GA account ID to enable tracking
-    "google_analytics_account": "UA-87210403-3",
-    # Specify a base_url used to generate sitemap.xml. If not
-    # specified, then no sitemap will be built.
-    "base_url": "https://mendeleev.readthedocs.io/en/stable/",
-    # Set the color and the accent color
-    "color_primary": "deep-orange",
-    "color_accent": "orange",
-    # Set the repo location to get a badge with stats
+    "icon": {
+        "repo": "fontawesome/brands/github",
+    },
+    "site_url": "https://mendeleev.readthedocs.io/en/stable/",
     "repo_url": "https://github.com/lmmentel/mendeleev/",
     "repo_name": "mendeleev",
-    # Visible levels of the global TOC; -1 means unlimited
-    "globaltoc_depth": 1,
-    # If False, expand all TOC entries
     "globaltoc_collapse": True,
-    # If True, show hidden TOC entries
-    "globaltoc_includehidden": True,
-    "heroes": {},
-    "nav_links": [],
+    "features": [
+        "navigation.expand",
+        "navigation.sections",
+        "navigation.top",
+        "search.share",
+        "search.suggest",
+        "toc.follow",
+        "toc.sticky",
+        "content.code.copy",
+    ],
+    "palette": [
+        {
+            "media": "(prefers-color-scheme: light)",
+            "scheme": "default",
+            "primary": "deep-orange",
+            "accent": "orange",
+            "toggle": {
+                "icon": "material/lightbulb",
+                "name": "Switch to dark mode",
+            },
+        },
+        {
+            "media": "(prefers-color-scheme: dark)",
+            "scheme": "slate",
+            "primary": "deep-orange",
+            "accent": "orange",
+            "toggle": {
+                "icon": "material/lightbulb-outline",
+                "name": "Switch to light mode",
+            },
+        },
+    ],
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,7 @@ autodoc_mock_imports = [
     "numpy",
     "matplotlib",
     "pandas",
+    "pyfiglet",
     "scipy",
     "seaborn",
 ]
@@ -67,6 +68,8 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinxcontrib.bibtex",
 ]
+
+nbsphinx_allow_errors = True
 
 # sphinxcontrib.bibtex settings
 bibtex_bibfiles = ["references.bib"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,6 +69,8 @@ extensions = [
     "sphinxcontrib.bibtex",
 ]
 
+nbsphinx_allow_errors = True
+
 # sphinxcontrib.bibtex settings
 bibtex_bibfiles = ["references.bib"]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -304,8 +304,20 @@ python_version = ".".join(map(str, sys.version_info[0:2]))
 
 
 intersphinx_mapping = {
-    "python": ("http://docs.python.org/", None),
-    "pandas": ("http://pandas.pydata.org/pandas-docs/dev", None),
+    "python": ("https://docs.python.org/3", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "sqlalchemy": ("https://docs.sqlalchemy.org/en/20/", None),
+    "pint": ("https://pint.readthedocs.io/en/stable/", None),
+}
+
+# autodoc configuration
+autodoc_default_options = {
+    "members": True,
+    "member-order": "bysource",
+    "special-members": "__init__",
+    "undoc-members": True,
+    "exclude-members": "__weakref__",
 }
 
 # mathjax downgrade to version to get plotly working in nbsphinx

--- a/docs/source/data_access.rst
+++ b/docs/source/data_access.rst
@@ -15,7 +15,7 @@ Accessing data
     - sql,
     - markdown.
 
-    All releases a tagged with the same version numbers as ``mendeeleev``.
+    All releases a tagged with the same version numbers as ``mendeleev``.
 
 Individual Elements
 -------------------
@@ -102,7 +102,7 @@ In order to use this functionality you'll need to clone the mendeleev repository
 
 .. code-block:: bash
 
-    gh clone lmmentel/mendeleev
+    git clone https://github.com/lmmentel/mendeleev.git
     cd mendeleev
     poetry install
     poetry run inv export

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,0 +1,347 @@
+.. _faq:
+
+**************************
+Frequently Asked Questions
+**************************
+
+General Questions
+=================
+
+What is mendeleev?
+------------------
+
+mendeleev is a Python library that provides a convenient API for accessing various
+properties of chemical elements, ions, and isotopes from the periodic table. It includes
+data on atomic properties, physical properties, ionization energies, isotopes, and more.
+
+How is mendeleev different from other periodic table libraries?
+----------------------------------------------------------------
+
+mendeleev offers:
+
+- **Comprehensive data**: Over 80 properties per element with proper citations
+- **Multiple data types**: Elements, isotopes, ions, and their relationships
+- **Electronegativity scales**: 15+ different scales, both stored and computed
+- **Visualization**: Built-in periodic table visualizations using bokeh, plotly, and seaborn
+- **Units support**: Integration with pint for proper physical units (v1.1.0+)
+- **Database backend**: SQLAlchemy-based for flexible data access
+
+See :doc:`quick` for related projects.
+
+Is mendeleev free to use?
+--------------------------
+
+Yes! mendeleev is released under the MIT license, making it free for both academic and
+commercial use. See :doc:`license_link` for full details.
+
+
+Installation & Setup
+====================
+
+How do I install mendeleev?
+----------------------------
+
+The recommended method is using conda:
+
+.. code-block:: bash
+
+    conda install conda-forge::mendeleev
+
+Or using pip:
+
+.. code-block:: bash
+
+    pip install mendeleev
+
+For visualization features:
+
+.. code-block:: bash
+
+    pip install mendeleev[vis]
+
+See :doc:`install` for more options.
+
+Which Python versions are supported?
+-------------------------------------
+
+mendeleev supports Python 3.9, 3.10, 3.11, 3.12, and 3.13.
+
+Do I need to download the database separately?
+-----------------------------------------------
+
+No, the database (``elements.db``) is included with the package and automatically
+available after installation.
+
+
+Using mendeleev
+===============
+
+How do I access element data?
+------------------------------
+
+There are several ways:
+
+.. code-block:: python
+
+    # Import by symbol directly
+    from mendeleev import Si
+    print(Si.name)  # 'Silicon'
+
+    # Use the element function with symbol, name, or atomic number
+    from mendeleev import element
+    si = element('Si')       # Symbol
+    si = element('Silicon')  # Name
+    si = element(14)         # Atomic number
+
+See :doc:`data_access` for more details.
+
+How do I get data for multiple elements?
+-----------------------------------------
+
+Use ``fetch_table()`` for bulk data access:
+
+.. code-block:: python
+
+    from mendeleev import fetch_table
+
+    # Get all elements as a pandas DataFrame
+    elements = fetch_table('elements')
+
+    # Filter and select specific data
+    alkali_metals = elements[elements['group_id'] == 1]
+    symbols = alkali_metals['symbol'].tolist()
+
+See :doc:`notebooks/bulk_data_access` tutorial.
+
+Can I access isotope data?
+---------------------------
+
+Yes, through the element's ``isotopes`` attribute:
+
+.. code-block:: python
+
+    from mendeleev import element
+
+    carbon = element('C')
+    for isotope in carbon.isotopes:
+        print(f"C-{isotope.mass_number}: {isotope.abundance}%")
+
+See :doc:`data` for available isotope properties.
+
+How do I create visualizations?
+--------------------------------
+
+Use the ``periodic_table()`` function:
+
+.. code-block:: python
+
+    from mendeleev.vis import periodic_table
+
+    # Create a periodic table colored by a property
+    periodic_table(colorby='atomic_radius')
+
+See :doc:`notebooks/visualizations` and :doc:`notebooks/advanced_visualizations` tutorials.
+
+What electronegativity scales are available?
+---------------------------------------------
+
+mendeleev provides 15+ electronegativity scales:
+
+- Stored: Allen, Ghosh, Pauling, Miedema, and more
+- Computed: Allred-Rochow, Mulliken, Sanderson, Cottrell-Sutton, and more
+
+.. code-block:: python
+
+    from mendeleev import element
+
+    si = element('Si')
+    print(si.en_pauling)           # Pauling scale
+    print(si.en_allen)             # Allen scale
+    print(si.en_mulliken())        # Mulliken (computed)
+
+See :doc:`electronegativity` for all available scales.
+
+
+Data & Citations
+================
+
+Where does the data come from?
+------------------------------
+
+All data includes proper citations to peer-reviewed sources. You can view sources for
+any property using the ``PropertyMetadata`` table:
+
+.. code-block:: python
+
+    from mendeleev import fetch_table
+
+    metadata = fetch_table('propertymetadata')
+    # View citation keys for a property
+    prop = metadata[metadata['attribute_name'] == 'atomic_radius']
+    print(prop[['attribute_name', 'citation_keys', 'description']])
+
+See :doc:`bibliography` for full references.
+
+How often is the data updated?
+-------------------------------
+
+The data is updated with new releases. Major updates include:
+
+- Version 1.1.0 (2024): Added units support, updated property metadata
+- Version 1.0.0 (2023): Major refactoring with pydantic models
+
+Check :doc:`changes_link` for version history.
+
+Can I export the data?
+----------------------
+
+Yes, using the export functionality:
+
+.. code-block:: bash
+
+    # Clone the repository
+    git clone https://github.com/lmmentel/mendeleev.git
+    cd mendeleev
+
+    # Export to multiple formats (CSV, JSON, HTML, Markdown, SQL)
+    poetry install
+    poetry run inv export
+
+Or access the raw data at `mendeleev-data <https://github.com/lmmentel/mendeleev-data>`_.
+
+Is the data accurate?
+---------------------
+
+We strive for accuracy and include citations for all data. However:
+
+- Some properties are only available for certain elements
+- Data may be updated as new measurements are published
+- Different sources may report slightly different values
+
+If you find an error, please `report it <https://github.com/lmmentel/mendeleev/issues>`_.
+
+
+Development & Contributing
+===========================
+
+How can I contribute?
+---------------------
+
+Contributions are welcome! You can:
+
+- Report bugs or data inconsistencies
+- Suggest new features
+- Add missing data with proper citations
+- Improve documentation
+- Submit pull requests
+
+See :doc:`CONTRIBUTING` for guidelines.
+
+How do I run the tests?
+------------------------
+
+.. code-block:: bash
+
+    # Install development dependencies
+    poetry install
+
+    # Run all tests
+    poetry run pytest
+
+    # Run with coverage
+    poetry run pytest --cov=mendeleev
+
+How do I build the documentation locally?
+------------------------------------------
+
+.. code-block:: bash
+
+    cd docs
+    make html
+
+    # View the docs
+    open build/html/index.html  # macOS
+    # or
+    xdg-open build/html/index.html  # Linux
+
+Can I use mendeleev in my research paper?
+------------------------------------------
+
+Yes! Please cite it as:
+
+    L. M. Mentel, *mendeleev* - A Python resource for properties of chemical
+    elements, ions and isotopes. , 2014-- . Available at:
+    https://github.com/lmmentel/mendeleev
+
+See :doc:`quick` for BibTeX and BibLaTeX formats.
+
+
+Performance
+===========
+
+Why is importing mendeleev slow?
+---------------------------------
+
+The initial import loads the database and models. To improve performance:
+
+- Import only what you need: ``from mendeleev import element``
+- Use bulk operations with ``fetch_table()`` instead of loops
+- Consider lazy imports in performance-critical code
+
+See :doc:`troubleshooting` for more optimization tips.
+
+How can I speed up data access?
+--------------------------------
+
+Use ``fetch_table()`` for bulk operations instead of accessing elements individually:
+
+.. code-block:: python
+
+    # Slow (don't do this)
+    from mendeleev import element
+    radii = [element(i).atomic_radius for i in range(1, 119)]
+
+    # Fast (do this)
+    from mendeleev import fetch_table
+    elements = fetch_table('elements')
+    radii = elements['atomic_radius'].tolist()
+
+
+Units & Conversions
+===================
+
+Does mendeleev support units?
+------------------------------
+
+Yes, starting from version 1.1.0, mendeleev integrates with the
+`pint <https://pint.readthedocs.io/>`_ library for unit support.
+
+See :doc:`units` for detailed information.
+
+What units are properties stored in?
+-------------------------------------
+
+Common units include:
+
+- Radii: picometers (pm)
+- Energies: electron volts (eV)
+- Temperatures: Kelvin (K)
+- Masses: Daltons (Da)
+- Densities: g/cm³
+
+Check the ``PropertyMetadata`` table for specific units:
+
+.. code-block:: python
+
+    from mendeleev import fetch_table
+    metadata = fetch_table('propertymetadata')
+    print(metadata[['attribute_name', 'unit']])
+
+
+Still Have Questions?
+=====================
+
+- Check :doc:`troubleshooting` for common issues
+- Search `GitHub Issues <https://github.com/lmmentel/mendeleev/issues>`_
+- Start a `Discussion <https://github.com/lmmentel/mendeleev/discussions>`_
+- Read the full :doc:`API Reference <api/api>`

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -26,7 +26,7 @@ mendeleev offers:
 - **Units support**: Integration with pint for proper physical units (v1.1.0+)
 - **Database backend**: SQLAlchemy-based for flexible data access
 
-See :doc:`quick` for related projects.
+See :doc:`citing` for related projects.
 
 Is mendeleev free to use?
 --------------------------
@@ -273,7 +273,7 @@ Yes! Please cite it as:
     elements, ions and isotopes. , 2014-- . Available at:
     https://github.com/lmmentel/mendeleev
 
-See :doc:`quick` for BibTeX and BibLaTeX formats.
+See :doc:`citing` for BibTeX and BibLaTeX formats.
 
 
 Performance

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -316,7 +316,17 @@ Does mendeleev support units?
 Yes, starting from version 1.1.0, mendeleev integrates with the
 `pint <https://pint.readthedocs.io/>`_ library for unit support.
 
-See :doc:`units` for detailed information.
+Append ``_u`` to any property name to get a ``pint.Quantity`` with units attached:
+
+.. code-block:: python
+
+    >>> from mendeleev import Fe
+    >>> Fe.atomic_weight_u
+    55.845 dalton
+    >>> Fe.melting_point_u.to('celsius')
+    1537.85 degree_Celsius
+
+See :doc:`units` for the full reference and :doc:`tutorials` for a hands-on notebook.
 
 What units are properties stored in?
 -------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -303,7 +303,7 @@ See :doc:`quick` for BibTeX and BibLaTeX formats.
    :maxdepth: 2
    :hidden:
 
-   Overview <quick>
+   Quick Start <quick>
    Installation <install>
    Tutorials <tutorials>
    Data <data>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,13 +15,101 @@ A Python package with a convenient API for accessing various properties of eleme
 in the periodic table. Visualize trends, explore chemical data, and integrate periodic table information
 into your scientific workflows.
 
+.. raw:: html
+
+   <p align="center">
+      <a href="https://pypi.python.org/pypi/mendeleev"><img src="https://img.shields.io/pypi/v/mendeleev.svg?style=flat-square&label=PyPI%20version" alt="PyPI version"></a>
+      <a href="https://pepy.tech/project/mendeleev"><img src="https://pepy.tech/badge/mendeleev" alt="Downloads"></a>
+      <a href="https://github.com/lmmentel/mendeleev"><img src="https://img.shields.io/github/stars/lmmentel/mendeleev?style=social" alt="GitHub stars"></a>
+      <a href="https://zenodo.org/badge/latestdoi/204296088"><img src="https://zenodo.org/badge/204296088.svg" alt="DOI"></a>
+   </p>
+
 .. image:: _static/img/mendeleev_periodic_series.png
    :width: 1000px
    :align: center
    :alt: Periodic table
 
+Why mendeleev?
+==============
+
+🎯 **For Researchers & Scientists**
+   Access peer-reviewed elemental data programmatically in your computational chemistry, materials science, or data science workflows. No more manual lookups or spreadsheet wrangling.
+
+💡 **For Educators & Students**
+   Explore periodic trends interactively, create custom visualizations, and integrate chemical data into Jupyter notebooks for teaching and learning.
+
+⚙️ **For Developers**
+   Simple, well-documented API with pandas integration. SQLAlchemy models for advanced queries. Type hints and unit support for production-ready code.
+
+🔬 **Trusted Data Sources**
+   All data comes from peer-reviewed scientific literature with proper citations. See our :doc:`bibliography <bibliography>` for complete references.
+
+Use Cases
+=========
+
+.. grid:: 3
+
+   .. grid-item-card:: 📊 Data Analysis
+
+      Analyze elemental properties across the periodic table, identify correlations, and discover trends.
+
+      .. code-block:: python
+
+         import mendeleev as mv
+         from mendeleev import fetch_table
+
+         # Get all elements as DataFrame
+         df = fetch_table('elements')
+
+         # Analyze electronegativity vs. ionization
+         correlation = df[['en_pauling', 'ionenergies']].corr()
+
+   .. grid-item-card:: 🧪 Materials Research
+
+      Screen elements for materials design based on properties like electronegativity, radius, or oxidation states.
+
+      .. code-block:: python
+
+         # Find elements with specific properties
+         candidates = [
+             e for e in mv.get_all_elements()
+             if e.en_pauling and 1.5 < e.en_pauling < 2.5
+             and e.atomic_radius and e.atomic_radius < 150
+         ]
+
+   .. grid-item-card:: 📈 Visualization
+
+      Create publication-quality periodic tables and interactive plots.
+
+      .. code-block:: python
+
+         from mendeleev.vis import periodic_table
+
+         # Create custom periodic table
+         fig = periodic_table(
+             attribute='atomic_weight',
+             title='Atomic Weight Distribution'
+         )
+
+Interactive Web App
+===================
+
+Try mendeleev in your browser without installing anything!
+
+.. raw:: html
+
+   <p align="center">
+      <a href="http://mendeleev.herokuapp.com/" style="display: inline-block; padding: 12px 24px; background: #ff6347; color: white; text-decoration: none; border-radius: 6px; font-weight: bold; margin: 10px;">
+         🌐 Launch Interactive Web App
+      </a>
+   </p>
+
+Explore the data, create custom periodic tables, and visualize correlations between properties at `mendeleev.herokuapp.com <http://mendeleev.herokuapp.com/>`_.
+
 Quick Installation
 ==================
+
+**Requirements:** Python 3.9, 3.10, 3.11, 3.12, or 3.13
 
 Install from conda-forge (recommended):
 
@@ -35,10 +123,16 @@ Or via pip:
 
    pip install mendeleev
 
+For development installation with visualization dependencies:
+
+.. code-block:: bash
+
+   pip install mendeleev[vis]
+
 Quick Start
 ===========
 
-Access element data directly:
+**Simple element access:**
 
 .. code-block:: python
 
@@ -52,14 +146,7 @@ Access element data directly:
    >>> si.thermal_conductivity
    149
 
-   >>> # Access isotopes
-   >>> for iso in si.isotopes:
-   ...     print(f"{iso.mass_number}: {iso.abundance}%")
-   28: 92.23%
-   29: 4.67%
-   30: 3.10%
-
-Or import elements by symbol:
+**Or import directly by symbol:**
 
 .. code-block:: python
 
@@ -69,26 +156,111 @@ Or import elements by symbol:
    >>> H.atomic_weight
    1.008
 
+**Access isotope data:**
+
+.. code-block:: python
+
+   >>> si = element('Si')
+   >>> for iso in si.isotopes:
+   ...     print(f"{iso.mass_number}: {iso.abundance}%")
+   28: 92.23%
+   29: 4.67%
+   30: 3.10%
+
+**Work with units (v1.1.0+):**
+
+.. code-block:: python
+
+   >>> from mendeleev import element
+   >>> from mendeleev.models import fetch_unit_metadata
+
+   >>> fe = element('Fe')
+   >>> meta = fetch_unit_metadata('atomic_radius')
+   >>> print(f"Radius: {fe.atomic_radius} {meta.units}")
+   Radius: 156 pm
+
+**Query multiple elements:**
+
+.. code-block:: python
+
+   >>> from mendeleev import fetch_table
+
+   >>> # Get all elements as pandas DataFrame
+   >>> df = fetch_table('elements')
+   >>> df[['symbol', 'name', 'atomic_number']].head()
+     symbol      name  atomic_number
+   0      H  Hydrogen              1
+   1     He    Helium              2
+   2     Li   Lithium              3
+   3     Be Beryllium              4
+   4      B     Boron              5
+
 Key Features
 ============
 
 📊 **Rich Dataset**
-   Access 100+ properties per element including atomic, physical, thermodynamic, and electronic data
+   100+ properties per element including atomic, physical, thermodynamic, and electronic data from peer-reviewed sources
 
 🔬 **Isotope Information**
-   Complete isotope data with abundances, masses, half-lives, and nuclear properties
+   Complete isotope data with abundances, masses, half-lives, decay modes, and nuclear properties
 
 📏 **Units Support** (v1.1.0+)
    Integration with `pint <https://pint.readthedocs.io/>`_ for unit-aware calculations and conversions
 
 📈 **Visualization**
-   Create custom periodic tables with `bokeh <https://bokeh.org/>`_ and explore trends interactively
+   Create custom periodic tables with `bokeh <https://bokeh.org/>`_, `plotly <https://plotly.com/>`_, and `seaborn <https://seaborn.pydata.org/>`_
 
 🗄️ **Data Access**
-   Query the SQLite database directly or export to pandas DataFrames
+   Query the SQLite database directly, export to pandas DataFrames, or use SQLAlchemy ORM for advanced queries
 
 ⚡ **Multiple Access Methods**
-   By symbol, name, atomic number, or bulk queries
+   Access by symbol, name, atomic number, or perform bulk queries with filtering
+
+🐍 **Pythonic API**
+   Clean, intuitive interface with type hints, docstrings, and extensive examples
+
+📚 **Well Documented**
+   Comprehensive documentation with interactive Jupyter notebook tutorials and API reference
+
+🧪 **Electronegativity Scales**
+   Calculate electronegativity using 14+ different scales (Pauling, Allred-Rochow, Mulliken, etc.)
+
+🔓 **Open Source**
+   MIT licensed, actively maintained, with contributions welcome
+
+What You Can Do
+===============
+
+.. grid:: 2
+   :gutter: 3
+
+   .. grid-item-card:: 🎓 **Education & Learning**
+
+      - Create interactive periodic table lessons
+      - Explore trends in Jupyter notebooks
+      - Generate quizzes and study materials
+      - Visualize periodic patterns
+
+   .. grid-item-card:: 🔬 **Research & Analysis**
+
+      - Screen elements for materials design
+      - Analyze property correlations
+      - Generate datasets for ML models
+      - Validate computational results
+
+   .. grid-item-card:: 📊 **Data Science**
+
+      - Export to pandas for analysis
+      - Create publication-quality plots
+      - Build chemical databases
+      - Integrate with existing workflows
+
+   .. grid-item-card:: 💻 **Software Development**
+
+      - Add chemistry features to apps
+      - Build chemical calculators
+      - Create web services with element data
+      - Develop educational software
 
 Explore the Documentation
 ==========================
@@ -141,7 +313,7 @@ Learn what data is available and how to use it.
       :link: electronegativity
       :link-type: doc
 
-      Calculate electronegativity using multiple scales and methods.
+      Calculate electronegativity using 14+ different scales and methods.
 
 API Documentation
 -----------------
@@ -193,6 +365,34 @@ Get help and contribute to the project.
 
       Data sources and references used in mendeleev.
 
+Community & Support
+===================
+
+.. grid:: 3
+
+   .. grid-item-card:: 💬 Discussions
+      :link: https://github.com/lmmentel/mendeleev/discussions
+
+      Ask questions, share ideas, and connect with other users.
+
+   .. grid-item-card:: 🐛 Issue Tracker
+      :link: https://github.com/lmmentel/mendeleev/issues
+
+      Report bugs, request features, or discuss data updates.
+
+   .. grid-item-card:: 📚 Source Code
+      :link: https://github.com/lmmentel/mendeleev
+
+      Browse the source code, contribute, or fork the project.
+
+Citing mendeleev
+================
+
+If you use mendeleev in your research, please cite:
+
+   L. M. Mentel, *mendeleev* - A Python resource for properties of chemical elements, ions and isotopes. 2014--. DOI: `10.5281/zenodo.204296088 <https://doi.org/10.5281/zenodo.204296088>`_
+
+See :doc:`quick` for BibTeX and BibLaTeX formats.
 
 .. toctree::
    :caption: Documentation

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,7 @@ the periodic table of elements.
    FAQ <faq>
    Troubleshooting <troubleshooting>
    Contributing guide <CONTRIBUTING>
+   API Overview <api_overview>
    API Reference <api/api>
    Bibliography <bibliography>
    Changes <changes_link>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,94 +44,19 @@ Why mendeleev?
 🔬 **Trusted Data Sources**
    All data comes from peer-reviewed scientific literature with proper citations. See our :doc:`bibliography <bibliography>` for complete references.
 
-Quick Installation
-==================
-
-**Requirements:** Python 3.9, 3.10, 3.11, 3.12, or 3.13
-
-Install from conda-forge (recommended):
-
-.. code-block:: bash
-
-   conda install conda-forge::mendeleev
-
-Or via pip:
-
-.. code-block:: bash
-
-   pip install mendeleev
-
-For development installation with visualization dependencies:
-
-.. code-block:: bash
-
-   pip install mendeleev[vis]
-
 Quick Start
 ===========
 
-**Simple element access:**
+See the :doc:`Quick Start guide <quick>` for copy-paste examples, or
+:doc:`install` for installation options.
 
 .. code-block:: python
 
-   >>> from mendeleev import element
+   from mendeleev import element
 
-   >>> si = element('Si')
-   >>> si.name
-   'Silicon'
-   >>> si.atomic_number
-   14
-   >>> si.thermal_conductivity
-   149
-
-**Or import directly by symbol:**
-
-.. code-block:: python
-
-   >>> from mendeleev import Fe, O, H
-   >>> Fe.name
-   'Iron'
-   >>> H.atomic_weight
-   1.008
-
-**Access isotope data:**
-
-.. code-block:: python
-
-   >>> si = element('Si')
-   >>> for iso in si.isotopes:
-   ...     print(f"{iso.mass_number}: {iso.abundance}%")
-   28: 92.23%
-   29: 4.67%
-   30: 3.10%
-
-**Work with units (v1.1.0+):**
-
-.. code-block:: python
-
-   >>> from mendeleev import element
-   >>> from mendeleev.models import fetch_unit_metadata
-
-   >>> fe = element('Fe')
-   >>> meta = fetch_unit_metadata('atomic_radius')
-   >>> print(f"Radius: {fe.atomic_radius} {meta.units}")
-   Radius: 156 pm
-
-**Query multiple elements:**
-
-.. code-block:: python
-
-   >>> from mendeleev import fetch_table
-
-   >>> # Get all elements as pandas DataFrame
-   >>> df = fetch_table('elements')
-   >>> df[['symbol', 'name', 'atomic_number']].head()
-     symbol      name  atomic_number
-   0      H  Hydrogen              1
-   1     He    Helium              2
-   2     Li   Lithium              3
-   3     Be Beryllium              4
-   4      B     Boron              5
+   si = element("Si")
+   print(si.name)           # Silicon
+   print(si.atomic_number)  # 14
 
 Key Features
 ============
@@ -292,29 +217,44 @@ Community & Support
 Citing mendeleev
 ================
 
-If you use mendeleev in your research, please cite:
-
-   L. M. Mentel, *mendeleev* - A Python resource for properties of chemical elements, ions and isotopes. 2014--. DOI: `10.5281/zenodo.204296088 <https://doi.org/10.5281/zenodo.204296088>`_
-
-See :doc:`quick` for BibTeX and BibLaTeX formats.
+If you use mendeleev in your research, see :doc:`citing` for citation formats and BibTeX entries.
 
 .. toctree::
-   :caption: Documentation
+   :caption: Getting Started
    :maxdepth: 2
    :hidden:
 
    Quick Start <quick>
    Installation <install>
    Tutorials <tutorials>
+
+.. toctree::
+   :caption: Data & Features
+   :maxdepth: 2
+   :hidden:
+
    Data <data>
    Accessing data <data_access>
    Units <units>
    Electronegativity <electronegativity>
-   FAQ <faq>
-   Troubleshooting <troubleshooting>
-   Contributing guide <CONTRIBUTING>
+
+.. toctree::
+   :caption: API Reference
+   :maxdepth: 2
+   :hidden:
+
    API Overview <api_overview>
    API Reference <api/api>
+
+.. toctree::
+   :caption: Community & Help
+   :maxdepth: 2
+   :hidden:
+
+   FAQ <faq>
+   Troubleshooting <troubleshooting>
+   Citing <citing>
+   Contributing guide <CONTRIBUTING>
    Bibliography <bibliography>
    Changes <changes_link>
    License <license_link>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,68 +44,6 @@ Why mendeleev?
 🔬 **Trusted Data Sources**
    All data comes from peer-reviewed scientific literature with proper citations. See our :doc:`bibliography <bibliography>` for complete references.
 
-Use Cases
-=========
-
-.. grid:: 3
-
-   .. grid-item-card:: 📊 Data Analysis
-
-      Analyze elemental properties across the periodic table, identify correlations, and discover trends.
-
-      .. code-block:: python
-
-         import mendeleev as mv
-         from mendeleev import fetch_table
-
-         # Get all elements as DataFrame
-         df = fetch_table('elements')
-
-         # Analyze electronegativity vs. ionization
-         correlation = df[['en_pauling', 'ionenergies']].corr()
-
-   .. grid-item-card:: 🧪 Materials Research
-
-      Screen elements for materials design based on properties like electronegativity, radius, or oxidation states.
-
-      .. code-block:: python
-
-         # Find elements with specific properties
-         candidates = [
-             e for e in mv.get_all_elements()
-             if e.en_pauling and 1.5 < e.en_pauling < 2.5
-             and e.atomic_radius and e.atomic_radius < 150
-         ]
-
-   .. grid-item-card:: 📈 Visualization
-
-      Create publication-quality periodic tables and interactive plots.
-
-      .. code-block:: python
-
-         from mendeleev.vis import periodic_table
-
-         # Create custom periodic table
-         fig = periodic_table(
-             attribute='atomic_weight',
-             title='Atomic Weight Distribution'
-         )
-
-Interactive Web App
-===================
-
-Try mendeleev in your browser without installing anything!
-
-.. raw:: html
-
-   <p align="center">
-      <a href="http://mendeleev.herokuapp.com/" style="display: inline-block; padding: 12px 24px; background: #ff6347; color: white; text-decoration: none; border-radius: 6px; font-weight: bold; margin: 10px;">
-         🌐 Launch Interactive Web App
-      </a>
-   </p>
-
-Explore the data, create custom periodic tables, and visualize correlations between properties at `mendeleev.herokuapp.com <http://mendeleev.herokuapp.com/>`_.
-
 Quick Installation
 ==================
 
@@ -198,69 +136,35 @@ Quick Start
 Key Features
 ============
 
-📊 **Rich Dataset**
+📊 **Rich Dataset** → :doc:`data`
    100+ properties per element including atomic, physical, thermodynamic, and electronic data from peer-reviewed sources
 
-🔬 **Isotope Information**
+🔬 **Isotope Information** → :doc:`data`
    Complete isotope data with abundances, masses, half-lives, decay modes, and nuclear properties
 
-📏 **Units Support** (v1.1.0+)
-   Integration with `pint <https://pint.readthedocs.io/>`_ for unit-aware calculations and conversions
+📏 **Units Support** → :doc:`units`
+   Integration with `pint <https://pint.readthedocs.io/>`_ for unit-aware calculations and conversions (v1.1.0+)
 
-📈 **Visualization**
+📈 **Visualization** → :doc:`tutorials`
    Create custom periodic tables with `bokeh <https://bokeh.org/>`_, `plotly <https://plotly.com/>`_, and `seaborn <https://seaborn.pydata.org/>`_
 
-🗄️ **Data Access**
+🗄️ **Data Access** → :doc:`data_access`
    Query the SQLite database directly, export to pandas DataFrames, or use SQLAlchemy ORM for advanced queries
 
-⚡ **Multiple Access Methods**
+⚡ **Multiple Access Methods** → :doc:`api_overview`
    Access by symbol, name, atomic number, or perform bulk queries with filtering
 
-🐍 **Pythonic API**
+🐍 **Pythonic API** → :doc:`api/api`
    Clean, intuitive interface with type hints, docstrings, and extensive examples
 
-📚 **Well Documented**
+📚 **Well Documented** → :doc:`tutorials`
    Comprehensive documentation with interactive Jupyter notebook tutorials and API reference
 
-🧪 **Electronegativity Scales**
+🧪 **Electronegativity Scales** → :doc:`electronegativity`
    Calculate electronegativity using 14+ different scales (Pauling, Allred-Rochow, Mulliken, etc.)
 
-🔓 **Open Source**
+🔓 **Open Source** → :doc:`CONTRIBUTING`
    MIT licensed, actively maintained, with contributions welcome
-
-What You Can Do
-===============
-
-.. grid:: 2
-   :gutter: 3
-
-   .. grid-item-card:: 🎓 **Education & Learning**
-
-      - Create interactive periodic table lessons
-      - Explore trends in Jupyter notebooks
-      - Generate quizzes and study materials
-      - Visualize periodic patterns
-
-   .. grid-item-card:: 🔬 **Research & Analysis**
-
-      - Screen elements for materials design
-      - Analyze property correlations
-      - Generate datasets for ML models
-      - Validate computational results
-
-   .. grid-item-card:: 📊 **Data Science**
-
-      - Export to pandas for analysis
-      - Create publication-quality plots
-      - Build chemical databases
-      - Integrate with existing workflows
-
-   .. grid-item-card:: 💻 **Software Development**
-
-      - Add chemistry features to apps
-      - Build chemical calculators
-      - Create web services with element data
-      - Develop educational software
 
 Explore the Documentation
 ==========================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,7 +27,10 @@ the periodic table of elements.
    Tutorials <tutorials>
    Data <data>
    Accessing data <data_access>
+   Units <units>
    Electronegativity <electronegativity>
+   FAQ <faq>
+   Troubleshooting <troubleshooting>
    Contributing guide <CONTRIBUTING>
    API Reference <api/api>
    Bibliography <bibliography>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,21 +6,198 @@ Welcome to mendeleev's documentation
 
 .. raw:: html
 
-   <img src="_static/img/name_and_logo.png" alt="Logo" style="display: block;margin-left: auto;margin-right: auto;"> 
+   <img src="_static/img/name_and_logo.png" alt="Logo" style="display: block;margin-left: auto;margin-right: auto;">
 
 
-This package provides an API for accessing various properties of elements from
-the periodic table of elements.
+**Pythonic periodic table of elements**
+
+A Python package with a convenient API for accessing various properties of elements, ions, and isotopes
+in the periodic table. Visualize trends, explore chemical data, and integrate periodic table information
+into your scientific workflows.
 
 .. image:: _static/img/mendeleev_periodic_series.png
    :width: 1000px
    :align: center
    :alt: Periodic table
 
+Quick Installation
+==================
+
+Install from conda-forge (recommended):
+
+.. code-block:: bash
+
+   conda install conda-forge::mendeleev
+
+Or via pip:
+
+.. code-block:: bash
+
+   pip install mendeleev
+
+Quick Start
+===========
+
+Access element data directly:
+
+.. code-block:: python
+
+   >>> from mendeleev import element
+
+   >>> si = element('Si')
+   >>> si.name
+   'Silicon'
+   >>> si.atomic_number
+   14
+   >>> si.thermal_conductivity
+   149
+
+   >>> # Access isotopes
+   >>> for iso in si.isotopes:
+   ...     print(f"{iso.mass_number}: {iso.abundance}%")
+   28: 92.23%
+   29: 4.67%
+   30: 3.10%
+
+Or import elements by symbol:
+
+.. code-block:: python
+
+   >>> from mendeleev import Fe, O, H
+   >>> Fe.name
+   'Iron'
+   >>> H.atomic_weight
+   1.008
+
+Key Features
+============
+
+📊 **Rich Dataset**
+   Access 100+ properties per element including atomic, physical, thermodynamic, and electronic data
+
+🔬 **Isotope Information**
+   Complete isotope data with abundances, masses, half-lives, and nuclear properties
+
+📏 **Units Support** (v1.1.0+)
+   Integration with `pint <https://pint.readthedocs.io/>`_ for unit-aware calculations and conversions
+
+📈 **Visualization**
+   Create custom periodic tables with `bokeh <https://bokeh.org/>`_ and explore trends interactively
+
+🗄️ **Data Access**
+   Query the SQLite database directly or export to pandas DataFrames
+
+⚡ **Multiple Access Methods**
+   By symbol, name, atomic number, or bulk queries
+
+Explore the Documentation
+==========================
+
+Getting Started
+---------------
+
+New to mendeleev? Start here!
+
+.. grid:: 2
+
+   .. grid-item-card:: 📖 Installation Guide
+      :link: install
+      :link-type: doc
+
+      Step-by-step installation instructions for conda, pip, and development setup.
+
+   .. grid-item-card:: 🚀 Tutorials
+      :link: tutorials
+      :link-type: doc
+
+      Interactive Jupyter notebooks covering common use cases and advanced features.
+
+Data & Features
+---------------
+
+Learn what data is available and how to use it.
+
+.. grid:: 2
+
+   .. grid-item-card:: 🔢 Available Data
+      :link: data
+      :link-type: doc
+
+      Comprehensive list of 100+ element properties with references and metadata.
+
+   .. grid-item-card:: 📊 Accessing Data
+      :link: data_access
+      :link-type: doc
+
+      Query elements, fetch tables, export to pandas, and work with the database.
+
+   .. grid-item-card:: 📏 Units Support
+      :link: units
+      :link-type: doc
+
+      Work with physical units using pint integration (v1.1.0+).
+
+   .. grid-item-card:: ⚡ Electronegativity
+      :link: electronegativity
+      :link-type: doc
+
+      Calculate electronegativity using multiple scales and methods.
+
+API Documentation
+-----------------
+
+Detailed API reference and architecture.
+
+.. grid:: 2
+
+   .. grid-item-card:: 🏗️ API Overview
+      :link: api_overview
+      :link-type: doc
+
+      Architecture, usage patterns, and decision flowchart for choosing the right approach.
+
+   .. grid-item-card:: 📚 API Reference
+      :link: api/api
+      :link-type: doc
+
+      Complete reference for all modules, classes, and functions.
+
+Help & Resources
+----------------
+
+Get help and contribute to the project.
+
+.. grid:: 2
+
+   .. grid-item-card:: ❓ FAQ
+      :link: faq
+      :link-type: doc
+
+      Frequently asked questions about installation, usage, and development.
+
+   .. grid-item-card:: 🔧 Troubleshooting
+      :link: troubleshooting
+      :link-type: doc
+
+      Common issues and solutions for data access, performance, and visualization.
+
+   .. grid-item-card:: 🤝 Contributing
+      :link: CONTRIBUTING
+      :link-type: doc
+
+      Learn how to contribute code, report bugs, and suggest enhancements.
+
+   .. grid-item-card:: 📖 Bibliography
+      :link: bibliography
+      :link-type: doc
+
+      Data sources and references used in mendeleev.
+
 
 .. toctree::
-   :caption: Contents
+   :caption: Documentation
    :maxdepth: 2
+   :hidden:
 
    Overview <quick>
    Installation <install>

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,23 +1,70 @@
+.. _installation:
 
 ************
 Installation
 ************
 
-The package can be installed using `pip <https://pypi.python.org/pypi/pip>`_
+Requirements
+============
+
+Python 3.9, 3.10, 3.11, 3.12, or 3.13.
+
+User installation
+=================
+
+pip
+---
 
 .. code-block:: bash
 
    pip install mendeleev
 
-You can also install the most recent version from the repository:
+With visualization support (bokeh, plotly, seaborn):
+
+.. code-block:: bash
+
+   pip install mendeleev[vis]
+
+conda-forge
+-----------
+
+.. code-block:: bash
+
+   conda install conda-forge::mendeleev
+
+Latest from source
+------------------
 
 .. code-block:: bash
 
    pip install git+https://github.com/lmmentel/mendeleev.git
 
-If you use `conda <https://conda.io/docs/intro.html>`_ you can install 
-the package from the `conda-forge channel <https://anaconda.org/conda-forge/mendeleev>`_ by 
+
+Development setup
+=================
+
+For contributors who want to run tests, build docs, or modify the code:
 
 .. code-block:: bash
 
-   conda install conda-forge::mendeleev
+   git clone https://github.com/lmmentel/mendeleev.git
+   cd mendeleev
+
+   # Install core dependencies
+   poetry install
+
+   # With visualization extras
+   poetry install --with vis
+
+   # Install pre-commit hooks (ruff lint + format)
+   pre-commit install
+
+   # Run tests
+   poetry run pytest
+
+   # Build docs
+   cd docs
+   poetry run pip install -r requirements.txt   # one-time
+   poetry run make html
+
+See :doc:`CONTRIBUTING` for full contribution guidelines.

--- a/docs/source/notebooks/working_with_units.ipynb
+++ b/docs/source/notebooks/working_with_units.ipynb
@@ -151,8 +151,8 @@
    "outputs": [],
    "source": [
     "# None values stay None\n",
-    "print(f\"H melting point: {H.melting_point}\")\n",
-    "print(f\"H melting point with units: {H.melting_point_u}\")\n",
+    "print(f\"H gas_basicity: {H.gas_basicity}\")\n",
+    "print(f\"H gas_basicity with units: {H.gas_basicity_u}\")\n",
     "\n",
     "# Properties without units raise AttributeError\n",
     "try:\n",

--- a/docs/source/notebooks/working_with_units.ipynb
+++ b/docs/source/notebooks/working_with_units.ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Working with Units\n",
+    "\n",
+    "The `mendeleev` package provides built-in support for accessing physical properties with their proper units using the [Pint](https://pint.readthedocs.io/) library.\n",
+    "\n",
+    "Simply append `_u` to any property name to get a `pint.Quantity` object with units attached."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mendeleev import H, C, Al, Fe\n",
+    "\n",
+    "# Without units (raw numbers, same as always)\n",
+    "print(f\"H atomic weight: {H.atomic_weight}\")\n",
+    "print(f\"C density: {C.density}\")\n",
+    "\n",
+    "# With units (pint Quantity objects)\n",
+    "print(f\"H atomic weight: {H.atomic_weight_u}\")\n",
+    "print(f\"C density: {C.density_u}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Unit Conversions\n",
+    "\n",
+    "The returned objects are [Pint Quantity](https://pint.readthedocs.io/en/stable/user/defining-quantities.html) instances that support unit conversions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Temperature conversions\n",
+    "al_melting = Al.melting_point_u\n",
+    "print(f\"Kelvin: {al_melting}\")\n",
+    "print(f\"Celsius: {al_melting.to('celsius')}\")\n",
+    "print(f\"Fahrenheit: {al_melting.to('fahrenheit')}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Length conversions\n",
+    "fe_radius = Fe.atomic_radius_u\n",
+    "print(f\"Picometers: {fe_radius}\")\n",
+    "print(f\"Angstroms: {fe_radius.to('angstrom')}\")\n",
+    "print(f\"Nanometers: {fe_radius.to('nanometer')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculations with Units\n",
+    "\n",
+    "pint Quantities support arithmetic while preserving dimensional correctness:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mendeleev.models import ureg\n",
+    "\n",
+    "# Calculate mass of a volume of aluminum\n",
+    "density = Al.density_u\n",
+    "volume = 100 * ureg.milliliter\n",
+    "mass = density * volume\n",
+    "\n",
+    "print(f\"Density: {density}\")\n",
+    "print(f\"Volume: {volume}\")\n",
+    "print(f\"Mass: {mass.to('gram')}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert electron affinity to different energy units\n",
+    "fe_ea = Fe.electron_affinity_u\n",
+    "print(f\"Electron affinity: {fe_ea}\")\n",
+    "print(f\"In joules: {fe_ea.to('joule')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with Multiple Elements\n",
+    "\n",
+    "Units make it easy to compare properties across elements:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elements = [Al, Fe, H, C]\n",
+    "\n",
+    "print(\"Element densities:\")\n",
+    "for el in elements:\n",
+    "    d = el.density_u\n",
+    "    if d is not None:\n",
+    "        print(f\"  {el.name}: {d}\")\n",
+    "    else:\n",
+    "        print(f\"  {el.name}: no data\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Handling Missing Data\n",
+    "\n",
+    "Properties with `None` values return `None` when accessed with `_u`. Properties without units defined raise `AttributeError`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# None values stay None\n",
+    "print(f\"H melting point: {H.melting_point}\")\n",
+    "print(f\"H melting point with units: {H.melting_point_u}\")\n",
+    "\n",
+    "# Properties without units raise AttributeError\n",
+    "try:\n",
+    "    print(H.symbol_u)\n",
+    "except AttributeError as e:\n",
+    "    print(f\"Error: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ionic Radii with Units\n",
+    "\n",
+    "Other model classes like `IonicRadius` also support the `_u` suffix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mendeleev.db import get_session\n",
+    "from mendeleev.models import IonicRadius\n",
+    "\n",
+    "session = get_session()\n",
+    "ionic = session.query(IonicRadius).first()\n",
+    "\n",
+    "print(f\"Charge: {ionic.charge_u}\")\n",
+    "print(f\"Ionic radius: {ionic.ionic_radius_u}\")\n",
+    "print(f\"Crystal radius: {ionic.crystal_radius_u}\")\n",
+    "\n",
+    "session.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "The `_u` suffix provides:\n",
+    "\n",
+    "- **Convenience** — append `_u` to any property for units\n",
+    "- **Conversions** — use `.to()` to convert between unit systems\n",
+    "- **Safety** — pint catches dimension mismatches in calculations\n",
+    "- **Transparency** — no guessing what units a number is in\n",
+    "\n",
+    "See the [units reference](https://mendeleev.readthedocs.io/en/stable/units.html) for the complete list of properties with units."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat_minor": 4,
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/quick.rst
+++ b/docs/source/quick.rst
@@ -1,37 +1,215 @@
+.. _quick-start:
 
-***************
-Getting started
-***************
+***********
+Quick Start
+***********
 
-Overview
+Install mendeleev (see :doc:`install` for details):
+
+.. code-block:: bash
+
+   pip install mendeleev
+
+Or with visualization support:
+
+.. code-block:: bash
+
+   pip install mendeleev[vis]
+
+All examples below work after ``pip install mendeleev``. No database download needed — it ships with the package.
+
+----
+
+1. Get an element by symbol
+===========================
+
+.. code-block:: python
+
+   from mendeleev import element
+
+   si = element("Si")
+   print(si.name)           # Silicon
+   print(si.atomic_number)  # 14
+
+2. Get an element by name or atomic number
+===========================================
+
+.. code-block:: python
+
+   from mendeleev import element
+
+   al = element("Aluminium")   # by name
+   o  = element(8)             # by atomic number
+   print(al.atomic_number)     # 13
+   print(o.name)               # Oxygen
+
+3. Import elements directly by symbol
+======================================
+
+.. code-block:: python
+
+   from mendeleev import Fe, O, H
+
+   print(Fe.name)           # Iron
+   print(H.atomic_weight)   # 1.008
+
+4. Get multiple elements at once
+=================================
+
+.. code-block:: python
+
+   from mendeleev import element
+
+   c, h, o = element(["C", "Hydrogen", 8])
+   print(c.name, h.name, o.name)  # Carbon Hydrogen Oxygen
+
+5. Access element properties
+=============================
+
+.. code-block:: python
+
+   from mendeleev import element
+
+   si = element("Si")
+   print(f"Atomic weight:      {si.atomic_weight}  Da")
+   print(f"Melting point:      {si.melting_point}  K")
+   print(f"Boiling point:      {si.boiling_point}  K")
+   print(f"Density:            {si.density}        g/cm³")
+   print(f"Electronegativity:  {si.en_pauling}")
+   print(f"Electron affinity:  {si.electron_affinity}  eV")
+
+6. Work with isotopes
+=====================
+
+.. code-block:: python
+
+   from mendeleev import element
+
+   carbon = element("C")
+   for iso in carbon.isotopes:
+       print(f"C-{iso.mass_number}: {iso.abundance}%")
+   # C-12: 98.93%
+   # C-13: 1.07%
+
+Access a specific isotope directly:
+
+.. code-block:: python
+
+   from mendeleev import isotope
+
+   c14 = isotope("C", 14)
+   print(f"Half-life: {c14.half_life} years")  # 5700.0
+
+7. Bulk data with pandas
+=========================
+
+.. code-block:: python
+
+   from mendeleev import fetch_table
+
+   df = fetch_table("elements")
+   print(df[["symbol", "name", "atomic_number", "atomic_weight"]].head())
+
+   # Filter and sort
+   heavy = df[df["atomic_number"] > 80]
+   print(heavy[["symbol", "name", "density"]].sort_values("density", ascending=False))
+
+8. Create a visualization
+==========================
+
+.. code-block:: python
+
+   from mendeleev.vis import periodic_table
+
+   # Interactive plot (requires bokeh or plotly)
+   periodic_table(colorby="atomic_radius", backend="plotly")
+
+   # Save a static plot
+   periodic_table(colorby="en_pauling", backend="seaborn", output="en_periodic.png")
+
+9. Work with ions
+=================
+
+.. code-block:: python
+
+   from mendeleev.ion import Ion
+
+   fe2 = Ion("Fe", charge=2)
+   fe3 = Ion("Fe", charge=3)
+   print(f"Ionic radius Fe²⁺: {fe2.ionic_radius} pm")
+   print(f"Ionic radius Fe³⁺: {fe3.ionic_radius} pm")
+
+10. Compare electronegativity scales
+=====================================
+
+.. code-block:: python
+
+   from mendeleev import fetch_electronegativities
+
+   en = fetch_electronegativities(["pauling", "allen", "mulliken"])
+   print(en[en["symbol"] == "Si"])
+
+Or access scales directly on an element:
+
+.. code-block:: python
+
+   from mendeleev import element
+
+   si = element("Si")
+   print(si.en_pauling)       # 1.9
+   print(si.en_allen)         # 11.33
+   print(si.en_mulliken())    # computed on the fly
+
+11. Unit-aware calculations
+============================
+
+.. code-block:: python
+
+   import pint
+   from mendeleev import element
+
+   ureg = pint.UnitRegistry()
+   si = element("Si")
+
+   radius = si.atomic_radius * ureg.pm
+   volume = (4 / 3) * 3.14159 * radius**3
+   print(volume.to("angstrom**3"))  # 9.6 angstrom ** 3
+
+12. Use the CLI
+===============
+
+.. code-block:: bash
+
+   element.py Si           # by symbol
+   element.py 14           # by atomic number
+   element.py Silicon      # by name
+
+Prints all available properties in the terminal (installed with the package).
+
+
+What next?
+==========
+
+* :doc:`api_overview` — choose the right function for your task
+* :doc:`tutorials` — Jupyter notebook tutorials
+* :doc:`data` — full list of 100+ available properties
+* :doc:`faq` — frequently asked questions
+* :doc:`troubleshooting` — common issues and solutions
+
+
+Appendix
 ========
 
-This package provides an API for accessing various properties of elements from
-the periodic table of elements. 
-
-
-The repository is hosted on `github <https://github.com/lmmentel/mendeleev>`_.
-
-Contributing
-============
-
-All contributions are welcome!
-
-If you would like to suggest an improvement or report a bug or data inconsistency please consider creating an
-`issue on github <https://github.com/lmmentel/mendeleev/issues>`_.
-I would be especially grateful for references to possible data updates and sources and recommendations of new data.
-
-
 Citing
-======
+------
 
-If you use *mendeleev* in a scientific publication, please consider citing the software as
+If you use mendeleev in a scientific publication, please cite:
 
-|    L. M. Mentel, *mendeleev* - A Python resource for properties of chemical elements, ions and isotopes. , 2014-- . Available at: `https://github.com/lmmentel/mendeleev <https://github.com/lmmentel/mendeleev>`_.
+   L. M. Mentel, *mendeleev* - A Python resource for properties of chemical
+   elements, ions and isotopes. , 2014-- .
+   Available at: https://github.com/lmmentel/mendeleev
 
-
-
-Here's the reference in the `BibLaTeX <https://www.ctan.org/pkg/biblatex?lang=en>`_ format
+BibLaTeX:
 
 .. code-block:: latex
 
@@ -43,29 +221,28 @@ Here's the reference in the `BibLaTeX <https://www.ctan.org/pkg/biblatex?lang=en
       date = {2014--},
   }
 
-or the older `BibTeX <http://www.bibtex.org/>`_ format
+BibTeX:
 
 .. code-block:: latex
 
    @misc{mendeleev2014,
       author = {Mentel, Łukasz},
-      title = {mendeleev} -- A Python resource for properties of chemical elements, ions and isotopes, ver. 1.1.0},
+      title = {mendeleev -- A Python resource for properties of chemical elements, ions and isotopes, ver. 1.1.0},
       howpublished = {\url{https://github.com/lmmentel/mendeleev}},
       year  = {2014--},
    }
 
-
 Related projects
-================
+----------------
 
 `periodictable <https://github.com/pkienzle/periodictable>`_
-    This package provides a periodic table of the elements with support for mass, density and xray/neutron scattering information.
+    Periodic table with mass, density and xray/neutron scattering information.
 
 `periodic <https://github.com/luisnaranjo733/periodic>`_
-    Periodic is an open source simple python API/command line script for the periodic table.
+    Simple Python API / CLI for the periodic table.
 
 Funding
-=======
+-------
 
 This project is supported by the RCN (The Research Council of Norway) project
 number 239193.

--- a/docs/source/quick.rst
+++ b/docs/source/quick.rst
@@ -160,20 +160,19 @@ Or access scales directly on an element:
    print(si.en_allen)         # 11.33
    print(si.en_mulliken())    # computed on the fly
 
-11. Unit-aware calculations
-============================
+11. Access properties with units
+=================================
 
 .. code-block:: python
 
-   import pint
-   from mendeleev import element
+   from mendeleev import Fe, Al
 
-   ureg = pint.UnitRegistry()
-   si = element("Si")
+   # Append _u to any property for a pint Quantity
+   print(Fe.atomic_weight_u)   # 55.845 dalton
+   print(Al.melting_point_u)   # 933.47 kelvin
 
-   radius = si.atomic_radius * ureg.pm
-   volume = (4 / 3) * 3.14159 * radius**3
-   print(volume.to("angstrom**3"))  # 9.6 angstrom ** 3
+   # Convert units easily
+   print(Al.melting_point_u.to("celsius"))  # 660.32 degree_Celsius
 
 12. Use the CLI
 ===============

--- a/docs/source/quick.rst
+++ b/docs/source/quick.rst
@@ -48,7 +48,7 @@ or the older `BibTeX <http://www.bibtex.org/>`_ format
 .. code-block:: latex
 
    @misc{mendeleev2014,
-      auhor = {Mentel, Łukasz},
+      author = {Mentel, Łukasz},
       title = {mendeleev} -- A Python resource for properties of chemical elements, ions and isotopes, ver. 1.1.0},
       howpublished = {\url{https://github.com/lmmentel/mendeleev}},
       year  = {2014--},

--- a/docs/source/quick.rst
+++ b/docs/source/quick.rst
@@ -188,61 +188,11 @@ Prints all available properties in the terminal (installed with the package).
 
 
 What next?
-==========
+=========
 
 * :doc:`api_overview` — choose the right function for your task
 * :doc:`tutorials` — Jupyter notebook tutorials
 * :doc:`data` — full list of 100+ available properties
 * :doc:`faq` — frequently asked questions
 * :doc:`troubleshooting` — common issues and solutions
-
-
-Appendix
-========
-
-Citing
-------
-
-If you use mendeleev in a scientific publication, please cite:
-
-   L. M. Mentel, *mendeleev* - A Python resource for properties of chemical
-   elements, ions and isotopes. , 2014-- .
-   Available at: https://github.com/lmmentel/mendeleev
-
-BibLaTeX:
-
-.. code-block:: latex
-
-   @software{mendeleev2014,
-      author = {Mentel, Łukasz},
-      title = {{mendeleev} -- A Python resource for properties of chemical elements, ions and isotopes},
-      url = {https://github.com/lmmentel/mendeleev},
-      version = {1.1.0},
-      date = {2014--},
-  }
-
-BibTeX:
-
-.. code-block:: latex
-
-   @misc{mendeleev2014,
-      author = {Mentel, Łukasz},
-      title = {mendeleev -- A Python resource for properties of chemical elements, ions and isotopes, ver. 1.1.0},
-      howpublished = {\url{https://github.com/lmmentel/mendeleev}},
-      year  = {2014--},
-   }
-
-Related projects
-----------------
-
-`periodictable <https://github.com/pkienzle/periodictable>`_
-    Periodic table with mass, density and xray/neutron scattering information.
-
-`periodic <https://github.com/luisnaranjo733/periodic>`_
-    Simple Python API / CLI for the periodic table.
-
-Funding
--------
-
-This project is supported by the RCN (The Research Council of Norway) project
-number 239193.
+* :doc:`citing` — citation formats and BibTeX entries

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -1,0 +1,320 @@
+.. _troubleshooting:
+
+***************
+Troubleshooting
+***************
+
+This page covers common issues and their solutions when using mendeleev.
+
+Installation Issues
+===================
+
+Missing Database File
+---------------------
+
+**Problem:** Error message about missing ``elements.db`` file.
+
+**Solution:**
+The database file should be included with the package installation. If it's missing:
+
+1. Reinstall the package:
+
+   .. code-block:: bash
+
+       pip uninstall mendeleev
+       pip install mendeleev
+
+2. If using development installation, ensure you're in the correct directory:
+
+   .. code-block:: bash
+
+       cd /path/to/mendeleev
+       poetry install
+
+Dependencies Not Installed
+---------------------------
+
+**Problem:** Import errors for optional dependencies like ``bokeh``, ``plotly``, or ``seaborn``.
+
+**Solution:**
+Install with visualization dependencies:
+
+.. code-block:: bash
+
+    # Using pip
+    pip install mendeleev[vis]
+
+    # Using poetry
+    poetry install --with vis
+
+    # Using conda
+    conda install -c conda-forge mendeleev bokeh plotly seaborn
+
+
+Data Access Issues
+==================
+
+Element Not Found
+-----------------
+
+**Problem:** ``NoResultFound`` or similar error when accessing an element.
+
+**Solution:**
+Ensure you're using a valid identifier (symbol, name, or atomic number):
+
+.. code-block:: python
+
+    from mendeleev import element
+
+    # Correct ways to access elements
+    si = element('Si')           # Symbol (case-sensitive)
+    si = element('Silicon')      # Name
+    si = element(14)             # Atomic number
+
+    # Common mistakes
+    # element('si')  # Wrong: lowercase symbol
+    # element('SI')  # Wrong: uppercase both letters
+
+Missing Property Data
+---------------------
+
+**Problem:** Property returns ``None`` or ``NaN``.
+
+**Solution:**
+Not all properties are available for all elements. Check if the data exists:
+
+.. code-block:: python
+
+    from mendeleev import element
+
+    el = element('H')
+
+    # Check before using
+    if el.atomic_radius is not None:
+        print(f"Atomic radius: {el.atomic_radius} pm")
+    else:
+        print("Atomic radius not available for this element")
+
+To see which elements have a specific property:
+
+.. code-block:: python
+
+    from mendeleev import fetch_table
+
+    elements = fetch_table('elements')
+    # Filter elements with atomic_radius data
+    has_radius = elements[elements['atomic_radius'].notna()]
+    print(f"Elements with atomic radius data: {len(has_radius)}")
+
+
+Database Lock Errors
+--------------------
+
+**Problem:** ``OperationalError: database is locked``
+
+**Solution:**
+This can occur when multiple processes try to access the database simultaneously.
+
+1. Ensure you close database sessions when done:
+
+   .. code-block:: python
+
+       from mendeleev.db import get_session
+
+       session = get_session()
+       try:
+           # Your database operations
+           pass
+       finally:
+           session.close()
+
+2. For read-only operations, use the higher-level API (``element()``, ``fetch_table()``)
+   instead of direct database access.
+
+
+Performance Issues
+==================
+
+Slow Import Times
+-----------------
+
+**Problem:** Importing mendeleev takes a long time.
+
+**Solution:**
+Import only what you need:
+
+.. code-block:: python
+
+    # Instead of importing all elements
+    # from mendeleev import *
+
+    # Import specific elements
+    from mendeleev import element, H, C, O
+
+    # Or use the element function
+    from mendeleev import element
+    si = element('Si')
+
+**Check import time:**
+
+.. code-block:: bash
+
+    poetry run inv timeimport
+
+Slow Data Fetching
+------------------
+
+**Problem:** Fetching large amounts of data is slow.
+
+**Solution:**
+
+1. Use ``fetch_table()`` for bulk data access instead of iterating over elements:
+
+   .. code-block:: python
+
+       # Slow approach
+       from mendeleev import element
+       data = []
+       for i in range(1, 119):
+           el = element(i)
+           data.append(el.atomic_radius)
+
+       # Fast approach
+       from mendeleev import fetch_table
+       elements = fetch_table('elements')
+       data = elements['atomic_radius'].tolist()
+
+2. Select only the columns you need:
+
+   .. code-block:: python
+
+       from mendeleev import fetch_table
+
+       # Get only specific columns
+       df = fetch_table('elements')
+       subset = df[['symbol', 'atomic_number', 'atomic_radius']]
+
+
+Visualization Issues
+====================
+
+Bokeh/Plotly Not Displaying
+----------------------------
+
+**Problem:** Visualizations don't show in Jupyter notebooks.
+
+**Solution:**
+
+For Bokeh:
+
+.. code-block:: python
+
+    from bokeh.io import output_notebook
+    output_notebook()
+
+    # Then create your visualization
+    from mendeleev.vis import periodic_table
+    periodic_table(...)
+
+For Plotly:
+
+.. code-block:: python
+
+    import plotly.io as pio
+    pio.renderers.default = "notebook"
+
+    # Then create your visualization
+
+Missing Visualization Dependencies
+-----------------------------------
+
+**Problem:** Import error for visualization modules.
+
+**Solution:**
+Install visualization dependencies:
+
+.. code-block:: bash
+
+    pip install mendeleev[vis]
+    # or
+    poetry install --with vis
+
+
+Type Hinting Issues
+===================
+
+MyPy or Type Checker Errors
+---------------------------
+
+**Problem:** Type checkers report errors when using mendeleev.
+
+**Solution:**
+Some type information may be incomplete. You can:
+
+1. Add type ignore comments for specific lines:
+
+   .. code-block:: python
+
+       from mendeleev import element
+       si = element('Si')  # type: ignore
+
+2. Install pandas-stubs for better pandas type support:
+
+   .. code-block:: bash
+
+       pip install pandas-stubs
+
+
+Data Inconsistencies
+====================
+
+Unexpected Property Values
+--------------------------
+
+**Problem:** A property value seems incorrect or outdated.
+
+**Solution:**
+
+1. Check the citation keys to see the data source:
+
+   .. code-block:: python
+
+       from mendeleev import fetch_table
+
+       metadata = fetch_table('propertymetadata')
+       prop_info = metadata[metadata['attribute_name'] == 'atomic_radius']
+       print(prop_info['citation_keys'])
+
+2. Report data issues on GitHub with:
+
+   - Element and property name
+   - Expected vs. actual value
+   - Reference to correct data source
+
+   `Report data issue → <https://github.com/lmmentel/mendeleev/issues/new>`_
+
+
+Getting Help
+============
+
+If you can't find a solution here:
+
+1. **Search existing issues**: `GitHub Issues <https://github.com/lmmentel/mendeleev/issues>`_
+2. **Start a discussion**: `GitHub Discussions <https://github.com/lmmentel/mendeleev/discussions>`_
+3. **Report a bug**: `Bug Report <https://github.com/lmmentel/mendeleev/issues/new?template=bug_report.md>`_
+
+When reporting issues, please include:
+
+- mendeleev version (``python -c "import mendeleev; print(mendeleev.__version__)"``）
+- Python version
+- Operating system
+- Minimal code example that reproduces the issue
+- Full error traceback
+
+See Also
+========
+
+- :doc:`Installation <install>`
+- :doc:`Getting started <quick>`
+- :doc:`FAQ <faq>`
+- :doc:`Contributing guide <CONTRIBUTING>`

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -8,6 +8,7 @@ Tutorials
    notebooks/quick_start.ipynb
    notebooks/bulk_data_access.ipynb
    notebooks/electronic_configuration.ipynb
+   notebooks/working_with_units.ipynb
    notebooks/ions.ipynb
    notebooks/visualizations.ipynb
    notebooks/advanced_visualizations.ipynb
@@ -27,6 +28,9 @@ notebooks on `binder <https://mybinder.org/>`_ where you can explore the example
 
 * `Electronic Configuration <https://mybinder.org/v2/gh/lmmentel/mendeleev/master?filepath=docs%2Fsource%2Fnotebooks%2Felectronic_configuration.ipynb>`_
   — Work with electronic configurations, manipulate subshells, and derive spectroscopic terms.
+
+* `Working with Units <https://mybinder.org/v2/gh/lmmentel/mendeleev/master?filepath=docs%2Fsource%2Fnotebooks%2Fworking_with_units.ipynb>`_
+  — Access properties with units, convert between unit systems, and do unit-aware calculations.
 
 * `Ions <https://mybinder.org/v2/gh/lmmentel/mendeleev/master?filepath=docs%2Fsource%2Fnotebooks%2Fions.ipynb>`_
   — Create ionic species, access charge-dependent radii and properties.

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -20,8 +20,19 @@ All tutorials are available as `Jupyter <https://jupyter.org/>`_
 notebooks on `binder <https://mybinder.org/>`_ where you can explore the examples interactively:
 
 * `Quick start <https://mybinder.org/v2/gh/lmmentel/mendeleev/master?filepath=docs%2Fsource%2Fnotebooks%2Fquick_start.ipynb>`_
+  — Basic capabilities: accessing elements, properties, and isotopes.
+
 * `Bulk data access <https://mybinder.org/v2/gh/lmmentel/mendeleev/master?filepath=docs%2Fsource%2Fnotebooks%2Fbulk_data_access.ipynb>`_
+  — Fetch full tables as pandas DataFrames; filter, sort, and analyze across all elements.
+
 * `Electronic Configuration <https://mybinder.org/v2/gh/lmmentel/mendeleev/master?filepath=docs%2Fsource%2Fnotebooks%2Felectronic_configuration.ipynb>`_
+  — Work with electronic configurations, manipulate subshells, and derive spectroscopic terms.
+
 * `Ions <https://mybinder.org/v2/gh/lmmentel/mendeleev/master?filepath=docs%2Fsource%2Fnotebooks%2Fions.ipynb>`_
+  — Create ionic species, access charge-dependent radii and properties.
+
 * `Visualizations <https://mybinder.org/v2/gh/lmmentel/mendeleev/master?filepath=docs%2Fsource%2Fnotebooks%2Fvisualizations.ipynb>`_
+  — Create periodic tables colored by element properties using bokeh, plotly, and seaborn.
+
 * `Advanced visualizations <https://mybinder.org/v2/gh/lmmentel/mendeleev/master?filepath=docs%2Fsource%2Fnotebooks%2Fadvanced_visualizations.ipynb>`_
+  — Lower-level plotting functions for custom visualizations beyond the default periodic table.

--- a/docs/source/units.rst
+++ b/docs/source/units.rst
@@ -1,0 +1,150 @@
+.. _units:
+
+****************************
+Working with Physical Units
+****************************
+
+.. versionadded:: 1.1.0
+
+As of version 1.1.0, mendeleev integrates with the `pint <https://pint.readthedocs.io/>`_
+library for proper handling of physical units and quantities. This allows you to work with
+element properties in a unit-aware manner, making conversions easier and reducing errors
+in calculations.
+
+Overview
+========
+
+The integration with pint provides:
+
+- **Unit-aware properties**: Physical properties are returned with their proper units
+- **Automatic conversions**: Easy conversion between different unit systems
+- **Dimensional analysis**: Ensures calculations are dimensionally correct
+- **Type safety**: Prevents mixing incompatible units
+
+Getting Property Metadata
+==========================
+
+You can access metadata about properties, including their units, using the
+:py:func:`fetch_table <mendeleev.fetch.fetch_table>` function::
+
+    >>> from mendeleev import fetch_table
+    >>> metadata = fetch_table('propertymetadata')
+    >>> # View properties with their units
+    >>> metadata[['attribute_name', 'unit']].head(10)
+
+This shows the units associated with each element property.
+
+Available Units
+===============
+
+Common units used in mendeleev include:
+
+**Length/Distance:**
+  - ``pm`` (picometers) - atomic and ionic radii
+  - ``bohr`` - Bohr radius units
+
+**Energy:**
+  - ``eV`` (electron volts) - ionization energies, electron affinities
+  - ``hartree`` - atomic units of energy
+
+**Temperature:**
+  - ``K`` (Kelvin) - melting points, boiling points
+
+**Pressure:**
+  - ``MPa`` (megapascals) - critical pressure
+
+**Mass:**
+  - ``Da`` (Daltons) - atomic weights
+  - ``g/cm^3`` - density
+
+**Other:**
+  - ``mg/kg`` - abundance in Earth's crust
+  - ``mg/L`` - abundance in seas
+  - ``cm^3/mol`` - atomic volume
+
+Working with Units
+==================
+
+Basic Usage
+-----------
+
+Element properties that have units are stored in the database with their unit information.
+The property metadata table contains this information::
+
+    >>> from mendeleev import element
+    >>> si = element('Si')
+    >>> # Access properties - units depend on the property
+    >>> si.atomic_radius  # in pm (picometers)
+    132
+    >>> si.boiling_point  # in K (Kelvin)
+    2628
+
+Converting Units
+----------------
+
+For unit conversions and dimensional analysis, you can use the pint library directly::
+
+    >>> import pint
+    >>> ureg = pint.UnitRegistry()
+    >>>
+    >>> # Convert atomic radius from pm to Angstroms
+    >>> radius_pm = 132 * ureg.pm
+    >>> radius_angstrom = radius_pm.to(ureg.angstrom)
+    >>> print(radius_angstrom)
+    1.32 angstrom
+    >>>
+    >>> # Convert boiling point from K to Celsius
+    >>> bp_kelvin = 2628 * ureg.K
+    >>> bp_celsius = bp_kelvin.to(ureg.degC)
+    >>> print(bp_celsius)
+    2354.85 degree_Celsius
+
+Unit-Aware Calculations
+-----------------------
+
+Using pint ensures dimensional correctness in calculations::
+
+    >>> import pint
+    >>> ureg = pint.UnitRegistry()
+    >>>
+    >>> # Calculate volume from radius (spherical approximation)
+    >>> from mendeleev import element
+    >>> import math
+    >>>
+    >>> si = element('Si')
+    >>> radius = si.atomic_radius * ureg.pm
+    >>> volume = (4/3) * math.pi * radius**3
+    >>> print(volume.to('angstrom**3'))
+    9.6 angstrom ** 3
+
+Property Metadata Reference
+============================
+
+The ``PropertyMetadata`` table contains comprehensive information about all stored properties:
+
+- ``attribute_name``: The property name as accessed in code
+- ``unit``: The unit of measurement (if applicable)
+- ``description``: Human-readable description
+- ``value_origin``: Whether the value is stored or computed
+- ``citation_keys``: References to source publications
+
+You can query this metadata to understand what units are used for each property::
+
+    >>> from mendeleev import fetch_table
+    >>> metadata = fetch_table('propertymetadata')
+    >>>
+    >>> # Find all properties with energy units
+    >>> energy_props = metadata[metadata['unit'].str.contains('eV', na=False)]
+    >>> print(energy_props[['attribute_name', 'unit', 'description']])
+
+See Also
+========
+
+- :doc:`Data reference <data>` - Complete list of available properties
+- :doc:`Data access <data_access>` - How to fetch and query data
+- `pint documentation <https://pint.readthedocs.io/>`_ - Full pint library documentation
+
+.. note::
+   While mendeleev integrates with pint for unit support, most properties are still
+   returned as numeric values in their documented units. Full pint Quantity objects
+   may be added in future versions for more seamless unit handling.

--- a/docs/source/units.rst
+++ b/docs/source/units.rst
@@ -6,145 +6,276 @@ Working with Physical Units
 
 .. versionadded:: 1.1.0
 
-As of version 1.1.0, mendeleev integrates with the `pint <https://pint.readthedocs.io/>`_
-library for proper handling of physical units and quantities. This allows you to work with
-element properties in a unit-aware manner, making conversions easier and reducing errors
-in calculations.
+mendeleev integrates with `pint <https://pint.readthedocs.io/>`_ to provide unit-aware
+access to physical properties. Append ``_u`` to any property name to get a
+`pint.Quantity <https://pint.readthedocs.io/en/stable/>`_ with proper units attached.
 
-Overview
-========
 
-The integration with pint provides:
+Quick Example
+=============
 
-- **Unit-aware properties**: Physical properties are returned with their proper units
-- **Automatic conversions**: Easy conversion between different unit systems
-- **Dimensional analysis**: Ensures calculations are dimensionally correct
-- **Type safety**: Prevents mixing incompatible units
+.. code-block:: python
 
-Getting Property Metadata
-==========================
+    >>> from mendeleev import Fe, Al
+    >>> Fe.atomic_weight_u
+    55.845 dalton
+    >>> Al.density_u
+    2.7 gram / centimeter ** 3
 
-You can access metadata about properties, including their units, using the
-:py:func:`fetch_table <mendeleev.fetch.fetch_table>` function::
+That's it — just add ``_u``.
 
-    >>> from mendeleev import fetch_table
-    >>> metadata = fetch_table('propertymetadata')
-    >>> # View properties with their units
-    >>> metadata[['attribute_name', 'unit']].head(10)
 
-This shows the units associated with each element property.
+How It Works
+============
 
-Available Units
-===============
+When you access ``element.property_u``, mendeleev:
 
-Common units used in mendeleev include:
+1. Strips the ``_u`` suffix to get the base property name.
+2. Looks up the unit in the ``PropertyMetadata`` database table.
+3. Multiplies the raw value by that unit using ``pint``.
+4. Returns a ``pint.Quantity`` object.
 
-**Length/Distance:**
-  - ``pm`` (picometers) - atomic and ionic radii
-  - ``bohr`` - Bohr radius units
+If the property doesn't exist, you'll get an ``AttributeError``. If it has no
+unit defined, you'll also get an ``AttributeError``. If the value is ``None``
+(missing data), the ``_u`` version returns ``None`` too.
 
-**Energy:**
-  - ``eV`` (electron volts) - ionization energies, electron affinities
-  - ``hartree`` - atomic units of energy
-
-**Temperature:**
-  - ``K`` (Kelvin) - melting points, boiling points
-
-**Pressure:**
-  - ``MPa`` (megapascals) - critical pressure
-
-**Mass:**
-  - ``Da`` (Daltons) - atomic weights
-  - ``g/cm^3`` - density
-
-**Other:**
-  - ``mg/kg`` - abundance in Earth's crust
-  - ``mg/L`` - abundance in seas
-  - ``cm^3/mol`` - atomic volume
-
-Working with Units
-==================
 
 Basic Usage
------------
+===========
 
-Element properties that have units are stored in the database with their unit information.
-The property metadata table contains this information::
+Accessing properties with units
+-------------------------------
 
-    >>> from mendeleev import element
-    >>> si = element('Si')
-    >>> # Access properties - units depend on the property
-    >>> si.atomic_radius  # in pm (picometers)
-    132
-    >>> si.boiling_point  # in K (Kelvin)
-    2628
+.. code-block:: python
 
-Converting Units
-----------------
+    >>> from mendeleev import H, C, Fe
+    >>> H.atomic_weight
+    1.008
+    >>> H.atomic_weight_u
+    1.008 dalton
+    >>> C.density
+    2.267
+    >>> C.density_u
+    2.267 gram / centimeter ** 3
 
-For unit conversions and dimensional analysis, you can use the pint library directly::
+Without the ``_u`` suffix, you get raw numbers (just like before). With it,
+you get pint Quantity objects that know their units.
 
-    >>> import pint
-    >>> ureg = pint.UnitRegistry()
-    >>>
-    >>> # Convert atomic radius from pm to Angstroms
-    >>> radius_pm = 132 * ureg.pm
-    >>> radius_angstrom = radius_pm.to(ureg.angstrom)
-    >>> print(radius_angstrom)
-    1.32 angstrom
-    >>>
-    >>> # Convert boiling point from K to Celsius
-    >>> bp_kelvin = 2628 * ureg.K
-    >>> bp_celsius = bp_kelvin.to(ureg.degC)
-    >>> print(bp_celsius)
-    2354.85 degree_Celsius
 
-Unit-Aware Calculations
------------------------
+Unit Conversions
+================
 
-Using pint ensures dimensional correctness in calculations::
+The returned Quantity objects support easy unit conversions:
 
-    >>> import pint
-    >>> ureg = pint.UnitRegistry()
-    >>>
-    >>> # Calculate volume from radius (spherical approximation)
-    >>> from mendeleev import element
-    >>> import math
-    >>>
-    >>> si = element('Si')
-    >>> radius = si.atomic_radius * ureg.pm
-    >>> volume = (4/3) * math.pi * radius**3
-    >>> print(volume.to('angstrom**3'))
-    9.6 angstrom ** 3
+.. code-block:: python
 
-Property Metadata Reference
-============================
+    >>> from mendeleev import Al, Fe
+    >>> Al.melting_point_u
+    933.47 kelvin
+    >>> Al.melting_point_u.to('celsius')
+    660.3199999999997 degree_Celsius
+    >>> Al.melting_point_u.to('fahrenheit')
+    1220.576 degree_Fahrenheit
 
-The ``PropertyMetadata`` table contains comprehensive information about all stored properties:
+.. code-block:: python
 
-- ``attribute_name``: The property name as accessed in code
-- ``unit``: The unit of measurement (if applicable)
-- ``description``: Human-readable description
-- ``value_origin``: Whether the value is stored or computed
-- ``citation_keys``: References to source publications
+    >>> Fe.atomic_radius_u
+    126 picometer
+    >>> Fe.atomic_radius_u.to('angstrom')
+    1.26 angstrom
 
-You can query this metadata to understand what units are used for each property::
 
-    >>> from mendeleev import fetch_table
-    >>> metadata = fetch_table('propertymetadata')
-    >>>
-    >>> # Find all properties with energy units
-    >>> energy_props = metadata[metadata['unit'].str.contains('eV', na=False)]
-    >>> print(energy_props[['attribute_name', 'unit', 'description']])
+Calculations with Units
+=======================
+
+pint Quantities support arithmetic while preserving dimensional correctness:
+
+.. code-block:: python
+
+    >>> from mendeleev import Al
+    >>> from mendeleev.models import ureg
+
+    >>> # Mass = density × volume
+    >>> density = Al.density_u
+    >>> volume = 100 * ureg.milliliter
+    >>> mass = density * volume
+    >>> mass.to('gram')
+    270.0 gram
+
+.. code-block:: python
+
+    >>> from mendeleev import Fe
+    >>> # Convert electron affinity to joules
+    >>> Fe.electron_affinity_u.to('joule')
+    3.9342e-19 joule
+
+The ``ureg`` (pint UnitRegistry) is available from ``mendeleev.models`` if you
+need to create new quantities for calculations.
+
+
+Error Handling
+==============
+
+Properties without units raise ``AttributeError``:
+
+.. code-block:: python
+
+    >>> from mendeleev import H
+    >>> H.symbol_u
+    Traceback (most recent call last):
+        ...
+    AttributeError: ...
+
+Properties with ``None`` values return ``None``:
+
+.. code-block:: python
+
+    >>> H.melting_point
+    None
+    >>> H.melting_point_u
+    None
+
+
+Supported Classes
+=================
+
+The ``_u`` suffix works on these model classes:
+
+- :py:class:`Element <mendeleev.models.Element>` — the main element class
+- :py:class:`IonicRadius <mendeleev.models.IonicRadius>`
+- :py:class:`IonizationEnergy <mendeleev.models.IonizationEnergy>`
+- :py:class:`Isotope <mendeleev.models.Isotope>`
+- :py:class:`PhaseTransition <mendeleev.models.PhaseTransition>`
+- :py:class:`ScatteringFactor <mendeleev.models.ScatteringFactor>`
+
+
+Properties with Units
+=====================
+
+Element properties with units
+-----------------------------
+
+**Atomic properties:**
+    - ``atomic_radius_u`` (pm) — Atomic radius
+    - ``atomic_radius_rahm_u`` (pm) — Atomic radius by Rahm et al.
+    - ``atomic_volume_u`` (cm³/mol) — Atomic volume
+    - ``atomic_weight_u`` (Da) — Relative atomic weight
+    - ``atomic_weight_uncertainty_u`` (Da) — Uncertainty in atomic weight
+
+**Abundance:**
+    - ``abundance_crust_u`` (mg/kg) — Abundance in Earth's crust
+    - ``abundance_sea_u`` (mg/L) — Abundance in seawater
+
+**Covalent radii:**
+    - ``covalent_radius_bragg_u`` (pm) — Bragg covalent radius
+    - ``covalent_radius_cordero_u`` (pm) — Cordero covalent radius
+    - ``covalent_radius_pyykko_u`` (pm) — Pyykkö single bond covalent radius
+    - ``covalent_radius_pyykko_double_u`` (pm) — Pyykkö double bond covalent radius
+    - ``covalent_radius_pyykko_triple_u`` (pm) — Pyykkö triple bond covalent radius
+
+**Van der Waals radii:**
+    - ``vdw_radius_u`` (pm) — Van der Waals radius
+    - ``vdw_radius_alvarez_u`` (pm) — Alvarez VdW radius
+    - ``vdw_radius_batsanov_u`` (pm) — Batsanov VdW radius
+    - ``vdw_radius_bondi_u`` (pm) — Bondi VdW radius
+    - ``vdw_radius_dreiding_u`` (pm) — Dreiding VdW radius
+    - ``vdw_radius_mm3_u`` (pm) — MM3 VdW radius
+    - ``vdw_radius_rt_u`` (pm) — RT VdW radius
+    - ``vdw_radius_truhlar_u`` (pm) — Truhlar VdW radius
+    - ``vdw_radius_uff_u`` (pm) — UFF VdW radius
+
+**Thermal properties:**
+    - ``boiling_point_u`` (K) — Boiling point
+    - ``melting_point_u`` (K) — Melting point
+    - ``critical_temperature_u`` (K) — Critical temperature
+    - ``critical_pressure_u`` (MPa) — Critical pressure
+    - ``triple_point_temperature_u`` (K) — Triple point temperature
+    - ``triple_point_pressure_u`` (kPa) — Triple point pressure
+    - ``evaporation_heat_u`` (kJ/mol) — Heat of vaporization
+    - ``fusion_heat_u`` (kJ/mol) — Heat of fusion
+    - ``heat_of_formation_u`` (kJ/mol) — Heat of formation
+    - ``molar_heat_capacity_u`` (J/mol/K) — Molar heat capacity
+    - ``specific_heat_capacity_u`` (J/g/K) — Specific heat capacity
+    - ``thermal_conductivity_u`` (W/m/K) — Thermal conductivity
+
+**Physical properties:**
+    - ``density_u`` (g/cm³) — Density
+    - ``lattice_constant_u`` (Å) — Lattice constant
+    - ``metallic_radius_u`` (pm) — Metallic radius
+    - ``metallic_radius_c12_u`` (pm) — Metallic radius (coordination 12)
+
+**Electronic properties:**
+    - ``dipole_polarizability_u`` (bohr³) — Dipole polarizability
+    - ``dipole_polarizability_unc_u`` (bohr³) — Uncertainty in dipole polarizability
+    - ``electron_affinity_u`` (eV) — Electron affinity
+    - ``c6_u`` (hartree/bohr⁶) — C₆ dispersion coefficient
+    - ``c6_gb_u`` (hartree/bohr⁶) — C₆ dispersion coefficient (Gould-Bučko)
+    - ``hardness_u`` (eV) — Chemical hardness
+    - ``softness_u`` (1/eV) — Chemical softness
+
+**Electronegativity scales:**
+    - ``electronegativity_allen_u`` (eV) — Allen electronegativity
+    - ``electronegativity_allred_rochow_u`` (e²/pm²) — Allred-Rochow electronegativity
+    - ``electronegativity_cottrell_sutton_u`` (e⁰·⁵/pm⁰·⁵) — Cottrell-Sutton electronegativity
+    - ``electronegativity_ghosh_u`` (1/pm) — Ghosh electronegativity
+    - ``electronegativity_gordy_u`` (e/pm) — Gordy electronegativity
+    - ``electronegativity_li_xue_u`` (1/pm) — Li-Xue electronegativity
+    - ``electronegativity_martynov_batsanov_u`` (eV⁰·⁵) — Martynov-Batsanov electronegativity
+    - ``electronegativity_mulliken_u`` (eV) — Mulliken electronegativity
+    - ``electronegativity_nagle_u`` (1/bohr) — Nagle electronegativity
+    - ``en_gunnarsson_lundqvist_u`` (eV) — Gunnarsson-Lundqvist electronegativity
+    - ``en_miedema_u`` (V) — Miedema electronegativity
+    - ``en_robles_bartolotti_u`` (eV) — Robles-Bartolotti electronegativity
+
+**Chemical properties:**
+    - ``gas_basicity_u`` (kJ/mol) — Gas basicity
+    - ``proton_affinity_u`` (kJ/mol) — Proton affinity
+
+**Economic properties:**
+    - ``price_per_kg_u`` (USD/kg) — Price per kilogram
+    - ``production_concentration_u`` (%) — Production concentration
+    - ``recycling_rate_u`` (%) — Recycling rate
+    - ``reserve_distribution_u`` (%) — Reserve distribution
+
+**Miedema parameters:**
+    - ``miedema_molar_volume_u`` (cm³) — Miedema molar volume
+
+
+Other classes with units
+------------------------
+
+**IonicRadius:**
+    - ``charge_u`` (e) — Ionic charge
+    - ``crystal_radius_u`` (pm) — Crystal radius
+    - ``ionic_radius_u`` (pm) — Ionic radius
+
+**IonizationEnergy:**
+    - ``ion_charge_u`` (e) — Ion charge
+    - ``ionization_energy_u`` (eV) — Ionization energy
+    - ``uncertainty_u`` (eV) — Uncertainty in ionization energy
+
+**Isotope:**
+    - ``mass_u`` (Da) — Isotopic mass
+    - ``mass_uncertainty_u`` (Da) — Uncertainty in isotopic mass
+    - ``quadrupole_moment_u`` (100 fm²) — Nuclear quadrupole moment
+    - ``quadrupole_moment_uncertainty_u`` (100 fm²) — Uncertainty in quadrupole moment
+
+**PhaseTransition:**
+    - ``boiling_point_u`` (K) — Boiling point
+    - ``critical_pressure_u`` (MPa) — Critical pressure
+    - ``critical_temperature_u`` (K) — Critical temperature
+    - ``melting_point_u`` (K) — Melting point
+    - ``triple_point_pressure_u`` (kPa) — Triple point pressure
+    - ``triple_point_temperature_u`` (K) — Triple point temperature
+
+**ScatteringFactor:**
+    - ``energy_u`` (eV) — Energy
+
 
 See Also
 ========
 
-- :doc:`Data reference <data>` - Complete list of available properties
-- :doc:`Data access <data_access>` - How to fetch and query data
-- `pint documentation <https://pint.readthedocs.io/>`_ - Full pint library documentation
-
-.. note::
-   While mendeleev integrates with pint for unit support, most properties are still
-   returned as numeric values in their documented units. Full pint Quantity objects
-   may be added in future versions for more seamless unit handling.
+- :doc:`Tutorials <tutorials>` — notebook tutorial on working with units
+- :doc:`Data reference <data>` — complete list of available properties
+- :doc:`Data access <data_access>` — how to fetch and query data
+- `pint documentation <https://pint.readthedocs.io/>`_ — full pint library docs

--- a/mendeleev/electronegativity.py
+++ b/mendeleev/electronegativity.py
@@ -216,7 +216,7 @@ def sanderson(radius: float, noble_gas_radius: float) -> float:
 
     """
 
-    return math.pow(noble_gas_radius / radius, 3)
+    return (noble_gas_radius / radius) ** 3
 
 
 def generic(zeff: float, radius: float, rpow: float = 1, apow: float = 1) -> float:

--- a/poetry.lock
+++ b/poetry.lock
@@ -68,11 +68,12 @@ version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
 ]
+markers = {dev = "python_version >= \"3.10\""}
 
 [package.source]
 type = "legacy"
@@ -99,6 +100,24 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 trio = ["trio (>=0.26.1)"]
+
+[package.source]
+type = "legacy"
+url = "https://pypi.org/simple"
+reference = "pypi-public"
+
+[[package]]
+name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+optional = false
+python-versions = "*"
+groups = ["dev"]
+markers = "python_version >= \"3.10\""
+files = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
 
 [package.source]
 type = "legacy"
@@ -218,7 +237,7 @@ version = "3.0.0"
 description = "Annotate AST trees with source code positions"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2"},
     {file = "asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7"},
@@ -356,7 +375,7 @@ version = "3.4.3"
 description = "Interactive plots and applications in the browser from Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["vis"]
+groups = ["main", "vis"]
 markers = "python_version == \"3.9\""
 files = [
     {file = "bokeh-3.4.3-py3-none-any.whl", hash = "sha256:c6f33817f866fc67fbeb5df79cd13a8bb592c05c591f3fd7f4f22b824f7afa01"},
@@ -385,7 +404,7 @@ version = "3.8.0"
 description = "Interactive plots and applications in the browser from Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["vis"]
+groups = ["main", "vis"]
 markers = "python_version >= \"3.10\""
 files = [
     {file = "bokeh-3.8.0-py3-none-any.whl", hash = "sha256:117c5e559231ad39fef87891a1a1b62b3bfefbaa47d536023537338f46015841"},
@@ -449,7 +468,7 @@ version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -536,7 +555,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
-markers = {vis = "implementation_name == \"pypy\""}
+markers = {main = "implementation_name == \"pypy\"", vis = "implementation_name == \"pypy\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -680,7 +699,7 @@ version = "0.2.3"
 description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417"},
     {file = "comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971"},
@@ -700,7 +719,7 @@ version = "1.3.0"
 description = "Python library for calculating contours of 2D quadrilateral grids"
 optional = false
 python-versions = ">=3.9"
-groups = ["vis"]
+groups = ["main", "vis"]
 markers = "python_version == \"3.9\""
 files = [
     {file = "contourpy-1.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:880ea32e5c774634f9fcd46504bf9f080a41ad855f4fef54f5380f5133d343c7"},
@@ -791,7 +810,7 @@ version = "1.3.2"
 description = "Python library for calculating contours of 2D quadrilateral grids"
 optional = false
 python-versions = ">=3.10"
-groups = ["vis"]
+groups = ["main", "vis"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "contourpy-1.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ba38e3f9f330af820c4b27ceb4b9c7feee5fe0493ea53a8720f4792667465934"},
@@ -874,7 +893,7 @@ version = "1.3.3"
 description = "Python library for calculating contours of 2D quadrilateral grids"
 optional = false
 python-versions = ">=3.11"
-groups = ["vis"]
+groups = ["main", "vis"]
 markers = "python_version >= \"3.11\""
 files = [
     {file = "contourpy-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:709a48ef9a690e1343202916450bc48b9e51c049b089c7f79a267b46cffcdaa1"},
@@ -1076,29 +1095,12 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
-name = "css-html-js-minify"
-version = "2.5.5"
-description = "CSS HTML JS Minifier"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "css-html-js-minify-2.5.5.zip", hash = "sha256:4a9f11f7e0496f5284d12111f3ba4ff5ff2023d12f15d195c9c48bd97013746c"},
-    {file = "css_html_js_minify-2.5.5-py2.py3-none-any.whl", hash = "sha256:3da9d35ac0db8ca648c1b543e0e801d7ca0bab9e6bfd8418fee59d5ae001727a"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.org/simple"
-reference = "pypi-public"
-
-[[package]]
 name = "cycler"
 version = "0.12.1"
 description = "Composable style cycles"
 optional = false
 python-versions = ">=3.8"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
     {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
@@ -1160,7 +1162,7 @@ version = "5.2.1"
 description = "Decorators for Humans"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a"},
     {file = "decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360"},
@@ -1251,7 +1253,7 @@ version = "1.3.0"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 markers = "python_version < \"3.11\""
 files = [
     {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
@@ -1295,7 +1297,7 @@ version = "2.2.1"
 description = "Get the currently executing AST node of a frame, and other information"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017"},
     {file = "executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4"},
@@ -1398,7 +1400,7 @@ version = "4.59.2"
 description = "Tools to manipulate font files"
 optional = false
 python-versions = ">=3.9"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "fonttools-4.59.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2a159e36ae530650acd13604f364b3a2477eff7408dcac6a640d74a3744d2514"},
     {file = "fonttools-4.59.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8bd733e47bf4c6dee2b2d8af7a1f7b0c091909b22dbb969a29b2b991e61e5ba4"},
@@ -1736,7 +1738,7 @@ version = "6.5.2"
 description = "Read resources from Python packages"
 optional = false
 python-versions = ">=3.9"
-groups = ["vis"]
+groups = ["main", "vis"]
 markers = "python_version == \"3.9\""
 files = [
     {file = "importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec"},
@@ -1838,7 +1840,7 @@ version = "8.18.1"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 markers = "python_version == \"3.9\""
 files = [
     {file = "ipython-8.18.1-py3-none-any.whl", hash = "sha256:e8267419d72d81955ec1177f8a29aaa90ac80ad647499201119e2f05e99aa397"},
@@ -1882,7 +1884,7 @@ version = "8.37.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 markers = "python_version >= \"3.10\""
 files = [
     {file = "ipython-8.37.0-py3-none-any.whl", hash = "sha256:ed87326596b878932dbcb171e3e698845434d8c61b8d8cd474bf663041a9dcf2"},
@@ -1927,7 +1929,7 @@ version = "8.1.7"
 description = "Jupyter interactive widgets"
 optional = false
 python-versions = ">=3.7"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "ipywidgets-8.1.7-py3-none-any.whl", hash = "sha256:764f2602d25471c213919b8a1997df04bef869251db4ca8efba1b76b1bd9f7bb"},
     {file = "ipywidgets-8.1.7.tar.gz", hash = "sha256:15f1ac050b9ccbefd45dccfbb2ef6bed0029d8278682d569d71b8dd96bee0376"},
@@ -1974,7 +1976,7 @@ version = "0.19.2"
 description = "An autocompletion tool for Python that can be used for text editors."
 optional = false
 python-versions = ">=3.6"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9"},
     {file = "jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0"},
@@ -1999,7 +2001,7 @@ version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -2115,7 +2117,7 @@ version = "4.0.5"
 description = "A Jupyter extension for rendering Bokeh content."
 optional = false
 python-versions = ">=3.8"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "jupyter_bokeh-4.0.5-py3-none-any.whl", hash = "sha256:1110076c14c779071cf492646a1a871aefa8a477261e4721327a666e65df1a2c"},
     {file = "jupyter_bokeh-4.0.5.tar.gz", hash = "sha256:a33d6ab85588f13640b30765fa15d1111b055cbe44f67a65ca57d3593af8245d"},
@@ -2406,7 +2408,7 @@ version = "3.0.15"
 description = "Jupyter interactive widgets for JupyterLab"
 optional = false
 python-versions = ">=3.7"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "jupyterlab_widgets-3.0.15-py3-none-any.whl", hash = "sha256:d59023d7d7ef71400d51e6fee9a88867f6e65e10a4201605d2d7f3e8f012a31c"},
     {file = "jupyterlab_widgets-3.0.15.tar.gz", hash = "sha256:2920888a0c2922351a9202817957a68c07d99673504d6cd37345299e971bb08b"},
@@ -2423,7 +2425,7 @@ version = "1.4.7"
 description = "A fast implementation of the Cassowary constraint solver"
 optional = false
 python-versions = ">=3.8"
-groups = ["vis"]
+groups = ["main", "vis"]
 markers = "python_version == \"3.9\""
 files = [
     {file = "kiwisolver-1.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8a9c83f75223d5e48b0bc9cb1bf2776cf01563e00ade8775ffe13b0b6e1af3a6"},
@@ -2553,7 +2555,7 @@ version = "1.4.9"
 description = "A fast implementation of the Cassowary constraint solver"
 optional = false
 python-versions = ">=3.10"
-groups = ["vis"]
+groups = ["main", "vis"]
 markers = "python_version >= \"3.10\""
 files = [
     {file = "kiwisolver-1.4.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b4b4d74bda2b8ebf4da5bd42af11d02d04428b2c32846e4c2c93219df8a7987b"},
@@ -2705,143 +2707,6 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
-name = "lxml"
-version = "6.0.1"
-description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "lxml-6.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3b38e20c578149fdbba1fd3f36cb1928a3aaca4b011dfd41ba09d11fb396e1b9"},
-    {file = "lxml-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:11a052cbd013b7140bbbb38a14e2329b6192478344c99097e378c691b7119551"},
-    {file = "lxml-6.0.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:21344d29c82ca8547ea23023bb8e7538fa5d4615a1773b991edf8176a870c1ea"},
-    {file = "lxml-6.0.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa8f130f4b2dc94baa909c17bb7994f0268a2a72b9941c872e8e558fd6709050"},
-    {file = "lxml-6.0.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4588806a721552692310ebe9f90c17ac6c7c5dac438cd93e3d74dd60531c3211"},
-    {file = "lxml-6.0.1-cp310-cp310-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:8466faa66b0353802fb7c054a400ac17ce2cf416e3ad8516eadeff9cba85b741"},
-    {file = "lxml-6.0.1-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50b5e54f6a9461b1e9c08b4a3420415b538d4773bd9df996b9abcbfe95f4f1fd"},
-    {file = "lxml-6.0.1-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:6f393e10685b37f15b1daef8aa0d734ec61860bb679ec447afa0001a31e7253f"},
-    {file = "lxml-6.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:07038c62fd0fe2743e2f5326f54d464715373c791035d7dda377b3c9a5d0ad77"},
-    {file = "lxml-6.0.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:7a44a5fb1edd11b3a65c12c23e1049c8ae49d90a24253ff18efbcb6aa042d012"},
-    {file = "lxml-6.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a57d9eb9aadf311c9e8785230eec83c6abb9aef2adac4c0587912caf8f3010b8"},
-    {file = "lxml-6.0.1-cp310-cp310-win32.whl", hash = "sha256:d877874a31590b72d1fa40054b50dc33084021bfc15d01b3a661d85a302af821"},
-    {file = "lxml-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:c43460f4aac016ee0e156bfa14a9de9b3e06249b12c228e27654ac3996a46d5b"},
-    {file = "lxml-6.0.1-cp310-cp310-win_arm64.whl", hash = "sha256:615bb6c73fed7929e3a477a3297a797892846b253d59c84a62c98bdce3849a0a"},
-    {file = "lxml-6.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c6acde83f7a3d6399e6d83c1892a06ac9b14ea48332a5fbd55d60b9897b9570a"},
-    {file = "lxml-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0d21c9cacb6a889cbb8eeb46c77ef2c1dd529cde10443fdeb1de847b3193c541"},
-    {file = "lxml-6.0.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:847458b7cd0d04004895f1fb2cca8e7c0f8ec923c49c06b7a72ec2d48ea6aca2"},
-    {file = "lxml-6.0.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1dc13405bf315d008fe02b1472d2a9d65ee1c73c0a06de5f5a45e6e404d9a1c0"},
-    {file = "lxml-6.0.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f540c229a8c0a770dcaf6d5af56a5295e0fc314fc7ef4399d543328054bcea"},
-    {file = "lxml-6.0.1-cp311-cp311-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:d2f73aef768c70e8deb8c4742fca4fd729b132fda68458518851c7735b55297e"},
-    {file = "lxml-6.0.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7f4066b85a4fa25ad31b75444bd578c3ebe6b8ed47237896341308e2ce923c3"},
-    {file = "lxml-6.0.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:0cce65db0cd8c750a378639900d56f89f7d6af11cd5eda72fde054d27c54b8ce"},
-    {file = "lxml-6.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c372d42f3eee5844b69dcab7b8d18b2f449efd54b46ac76970d6e06b8e8d9a66"},
-    {file = "lxml-6.0.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:2e2b0e042e1408bbb1c5f3cfcb0f571ff4ac98d8e73f4bf37c5dd179276beedd"},
-    {file = "lxml-6.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cc73bb8640eadd66d25c5a03175de6801f63c535f0f3cf50cac2f06a8211f420"},
-    {file = "lxml-6.0.1-cp311-cp311-win32.whl", hash = "sha256:7c23fd8c839708d368e406282d7953cee5134f4592ef4900026d84566d2b4c88"},
-    {file = "lxml-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:2516acc6947ecd3c41a4a4564242a87c6786376989307284ddb115f6a99d927f"},
-    {file = "lxml-6.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:cb46f8cfa1b0334b074f40c0ff94ce4d9a6755d492e6c116adb5f4a57fb6ad96"},
-    {file = "lxml-6.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c03ac546adaabbe0b8e4a15d9ad815a281afc8d36249c246aecf1aaad7d6f200"},
-    {file = "lxml-6.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33b862c7e3bbeb4ba2c96f3a039f925c640eeba9087a4dc7a572ec0f19d89392"},
-    {file = "lxml-6.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7a3ec1373f7d3f519de595032d4dcafae396c29407cfd5073f42d267ba32440d"},
-    {file = "lxml-6.0.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03b12214fb1608f4cffa181ec3d046c72f7e77c345d06222144744c122ded870"},
-    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:207ae0d5f0f03b30f95e649a6fa22aa73f5825667fee9c7ec6854d30e19f2ed8"},
-    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:32297b09ed4b17f7b3f448de87a92fb31bb8747496623483788e9f27c98c0f00"},
-    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e18224ea241b657a157c85e9cac82c2b113ec90876e01e1f127312006233756"},
-    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a07a994d3c46cd4020c1ea566345cf6815af205b1e948213a4f0f1d392182072"},
-    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:2287fadaa12418a813b05095485c286c47ea58155930cfbd98c590d25770e225"},
-    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b4e597efca032ed99f418bd21314745522ab9fa95af33370dcee5533f7f70136"},
-    {file = "lxml-6.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9696d491f156226decdd95d9651c6786d43701e49f32bf23715c975539aa2b3b"},
-    {file = "lxml-6.0.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:e4e3cd3585f3c6f87cdea44cda68e692cc42a012f0131d25957ba4ce755241a7"},
-    {file = "lxml-6.0.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:45cbc92f9d22c28cd3b97f8d07fcefa42e569fbd587dfdac76852b16a4924277"},
-    {file = "lxml-6.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f8c9bcfd2e12299a442fba94459adf0b0d001dbc68f1594439bfa10ad1ecb74b"},
-    {file = "lxml-6.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1e9dc2b9f1586e7cd77753eae81f8d76220eed9b768f337dc83a3f675f2f0cf9"},
-    {file = "lxml-6.0.1-cp312-cp312-win32.whl", hash = "sha256:987ad5c3941c64031f59c226167f55a04d1272e76b241bfafc968bdb778e07fb"},
-    {file = "lxml-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:abb05a45394fd76bf4a60c1b7bec0e6d4e8dfc569fc0e0b1f634cd983a006ddc"},
-    {file = "lxml-6.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:c4be29bce35020d8579d60aa0a4e95effd66fcfce31c46ffddf7e5422f73a299"},
-    {file = "lxml-6.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:485eda5d81bb7358db96a83546949c5fe7474bec6c68ef3fa1fb61a584b00eea"},
-    {file = "lxml-6.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d12160adea318ce3d118f0b4fbdff7d1225c75fb7749429541b4d217b85c3f76"},
-    {file = "lxml-6.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48c8d335d8ab72f9265e7ba598ae5105a8272437403f4032107dbcb96d3f0b29"},
-    {file = "lxml-6.0.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:405e7cf9dbdbb52722c231e0f1257214202dfa192327fab3de45fd62e0554082"},
-    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:299a790d403335a6a057ade46f92612ebab87b223e4e8c5308059f2dc36f45ed"},
-    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:48da704672f6f9c461e9a73250440c647638cc6ff9567ead4c3b1f189a604ee8"},
-    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:21e364e1bb731489e3f4d51db416f991a5d5da5d88184728d80ecfb0904b1d68"},
-    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bce45a2c32032afddbd84ed8ab092130649acb935536ef7a9559636ce7ffd4a"},
-    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:fa164387ff20ab0e575fa909b11b92ff1481e6876835014e70280769920c4433"},
-    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7587ac5e000e1594e62278422c5783b34a82b22f27688b1074d71376424b73e8"},
-    {file = "lxml-6.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:57478424ac4c9170eabf540237125e8d30fad1940648924c058e7bc9fb9cf6dd"},
-    {file = "lxml-6.0.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:09c74afc7786c10dd6afaa0be2e4805866beadc18f1d843cf517a7851151b499"},
-    {file = "lxml-6.0.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7fd70681aeed83b196482d42a9b0dc5b13bab55668d09ad75ed26dff3be5a2f5"},
-    {file = "lxml-6.0.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:10a72e456319b030b3dd900df6b1f19d89adf06ebb688821636dc406788cf6ac"},
-    {file = "lxml-6.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b0fa45fb5f55111ce75b56c703843b36baaf65908f8b8d2fbbc0e249dbc127ed"},
-    {file = "lxml-6.0.1-cp313-cp313-win32.whl", hash = "sha256:01dab65641201e00c69338c9c2b8a0f2f484b6b3a22d10779bb417599fae32b5"},
-    {file = "lxml-6.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:bdf8f7c8502552d7bff9e4c98971910a0a59f60f88b5048f608d0a1a75e94d1c"},
-    {file = "lxml-6.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:a6aeca75959426b9fd8d4782c28723ba224fe07cfa9f26a141004210528dcbe2"},
-    {file = "lxml-6.0.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:29b0e849ec7030e3ecb6112564c9f7ad6881e3b2375dd4a0c486c5c1f3a33859"},
-    {file = "lxml-6.0.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:02a0f7e629f73cc0be598c8b0611bf28ec3b948c549578a26111b01307fd4051"},
-    {file = "lxml-6.0.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:beab5e54de016e730875f612ba51e54c331e2fa6dc78ecf9a5415fc90d619348"},
-    {file = "lxml-6.0.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:92a08aefecd19ecc4ebf053c27789dd92c87821df2583a4337131cf181a1dffa"},
-    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36c8fa7e177649470bc3dcf7eae6bee1e4984aaee496b9ccbf30e97ac4127fa2"},
-    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:5d08e0f1af6916267bb7eff21c09fa105620f07712424aaae09e8cb5dd4164d1"},
-    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9705cdfc05142f8c38c97a61bd3a29581ceceb973a014e302ee4a73cc6632476"},
-    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74555e2da7c1636e30bff4e6e38d862a634cf020ffa591f1f63da96bf8b34772"},
-    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:e38b5f94c5a2a5dadaddd50084098dfd005e5a2a56cd200aaf5e0a20e8941782"},
-    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a5ec101a92ddacb4791977acfc86c1afd624c032974bfb6a21269d1083c9bc49"},
-    {file = "lxml-6.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5c17e70c82fd777df586c12114bbe56e4e6f823a971814fd40dec9c0de518772"},
-    {file = "lxml-6.0.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:45fdd0415a0c3d91640b5d7a650a8f37410966a2e9afebb35979d06166fd010e"},
-    {file = "lxml-6.0.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:d417eba28981e720a14fcb98f95e44e7a772fe25982e584db38e5d3b6ee02e79"},
-    {file = "lxml-6.0.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:8e5d116b9e59be7934febb12c41cce2038491ec8fdb743aeacaaf36d6e7597e4"},
-    {file = "lxml-6.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c238f0d0d40fdcb695c439fe5787fa69d40f45789326b3bb6ef0d61c4b588d6e"},
-    {file = "lxml-6.0.1-cp314-cp314-win32.whl", hash = "sha256:537b6cf1c5ab88cfd159195d412edb3e434fee880f206cbe68dff9c40e17a68a"},
-    {file = "lxml-6.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:911d0a2bb3ef3df55b3d97ab325a9ca7e438d5112c102b8495321105d25a441b"},
-    {file = "lxml-6.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:2834377b0145a471a654d699bdb3a2155312de492142ef5a1d426af2c60a0a31"},
-    {file = "lxml-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9283997edb661ebba05314da1b9329e628354be310bbf947b0faa18263c5df1b"},
-    {file = "lxml-6.0.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1beca37c6e7a4ddd1ca24829e2c6cb60b5aad0d6936283b5b9909a7496bd97af"},
-    {file = "lxml-6.0.1-cp38-cp38-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:42897fe8cb097274087fafc8251a39b4cf8d64a7396d49479bdc00b3587331cb"},
-    {file = "lxml-6.0.1-cp38-cp38-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ef8cd44a080bfb92776047d11ab64875faf76e0d8be20ea3ff0c1e67b3fc9cb"},
-    {file = "lxml-6.0.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:433ab647dad6a9fb31418ccd3075dcb4405ece75dced998789fe14a8e1e3785c"},
-    {file = "lxml-6.0.1-cp38-cp38-win32.whl", hash = "sha256:bfa30ef319462242333ef8f0c7631fb8b8b8eae7dca83c1f235d2ea2b7f8ff2b"},
-    {file = "lxml-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:7f36e4a2439d134b8e70f92ff27ada6fb685966de385668e21c708021733ead1"},
-    {file = "lxml-6.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:edb975280633a68d0988b11940834ce2b0fece9f5278297fc50b044cb713f0e1"},
-    {file = "lxml-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d4c5acb9bc22f2026bbd0ecbfdb890e9b3e5b311b992609d35034706ad111b5d"},
-    {file = "lxml-6.0.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47ab1aff82a95a07d96c1eff4eaebec84f823e0dfb4d9501b1fbf9621270c1d3"},
-    {file = "lxml-6.0.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:faa7233bdb7a4365e2411a665d034c370ac82798a926e65f76c26fbbf0fd14b7"},
-    {file = "lxml-6.0.1-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c71a0ce0e08c7e11e64895c720dc7752bf064bfecd3eb2c17adcd7bfa8ffb22c"},
-    {file = "lxml-6.0.1-cp39-cp39-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:57744270a512a93416a149f8b6ea1dbbbee127f5edcbcd5adf28e44b6ff02f33"},
-    {file = "lxml-6.0.1-cp39-cp39-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e89d977220f7b1f0c725ac76f5c65904193bd4c264577a3af9017de17560ea7e"},
-    {file = "lxml-6.0.1-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:0c8f7905f1971c2c408badf49ae0ef377cc54759552bcf08ae7a0a8ed18999c2"},
-    {file = "lxml-6.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ea27626739e82f2be18cbb1aff7ad59301c723dc0922d9a00bc4c27023f16ab7"},
-    {file = "lxml-6.0.1-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:21300d8c1bbcc38925aabd4b3c2d6a8b09878daf9e8f2035f09b5b002bcddd66"},
-    {file = "lxml-6.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:021497a94907c5901cd49d24b5b0fdd18d198a06611f5ce26feeb67c901b92f2"},
-    {file = "lxml-6.0.1-cp39-cp39-win32.whl", hash = "sha256:620869f2a3ec1475d000b608024f63259af8d200684de380ccb9650fbc14d1bb"},
-    {file = "lxml-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:afae3a15889942426723839a3cf56dab5e466f7d873640a7a3c53abc671e2387"},
-    {file = "lxml-6.0.1-cp39-cp39-win_arm64.whl", hash = "sha256:2719e42acda8f3444a0d88204fd90665116dda7331934da4d479dd9296c33ce2"},
-    {file = "lxml-6.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0abfbaf4ebbd7fd33356217d317b6e4e2ef1648be6a9476a52b57ffc6d8d1780"},
-    {file = "lxml-6.0.1-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ebbf2d9775be149235abebdecae88fe3b3dd06b1797cd0f6dffe6948e85309d"},
-    {file = "lxml-6.0.1-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a389e9f11c010bd30531325805bbe97bdf7f728a73d0ec475adef57ffec60547"},
-    {file = "lxml-6.0.1-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f5cf2addfbbe745251132c955ad62d8519bb4b2c28b0aa060eca4541798d86e"},
-    {file = "lxml-6.0.1-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1b60a3287bf33a2a54805d76b82055bcc076e445fd539ee9ae1fe85ed373691"},
-    {file = "lxml-6.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:f7bbfb0751551a8786915fc6b615ee56344dacc1b1033697625b553aefdd9837"},
-    {file = "lxml-6.0.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b556aaa6ef393e989dac694b9c95761e32e058d5c4c11ddeef33f790518f7a5e"},
-    {file = "lxml-6.0.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:64fac7a05ebb3737b79fd89fe5a5b6c5546aac35cfcfd9208eb6e5d13215771c"},
-    {file = "lxml-6.0.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:038d3c08babcfce9dc89aaf498e6da205efad5b7106c3b11830a488d4eadf56b"},
-    {file = "lxml-6.0.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:445f2cee71c404ab4259bc21e20339a859f75383ba2d7fb97dfe7c163994287b"},
-    {file = "lxml-6.0.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e352d8578e83822d70bea88f3d08b9912528e4c338f04ab707207ab12f4b7aac"},
-    {file = "lxml-6.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:51bd5d1a9796ca253db6045ab45ca882c09c071deafffc22e06975b7ace36300"},
-    {file = "lxml-6.0.1.tar.gz", hash = "sha256:2b3a882ebf27dd026df3801a87cf49ff791336e0f94b0fad195db77e01240690"},
-]
-
-[package.extras]
-cssselect = ["cssselect (>=0.7)"]
-html-clean = ["lxml_html_clean"]
-html5 = ["html5lib"]
-htmlsoup = ["BeautifulSoup4"]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.org/simple"
-reference = "pypi-public"
-
-[[package]]
 name = "mako"
 version = "1.3.10"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
@@ -2872,7 +2737,7 @@ version = "3.0.2"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8"},
     {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158"},
@@ -2948,7 +2813,7 @@ version = "3.9.4"
 description = "Python plotting package"
 optional = false
 python-versions = ">=3.9"
-groups = ["vis"]
+groups = ["main", "vis"]
 markers = "python_version == \"3.9\""
 files = [
     {file = "matplotlib-3.9.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c5fdd7abfb706dfa8d307af64a87f1a862879ec3cd8d0ec8637458f0885b9c50"},
@@ -3020,7 +2885,7 @@ version = "3.10.6"
 description = "Python plotting package"
 optional = false
 python-versions = ">=3.10"
-groups = ["vis"]
+groups = ["main", "vis"]
 markers = "python_version >= \"3.10\""
 files = [
     {file = "matplotlib-3.10.6-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:bc7316c306d97463a9866b89d5cc217824e799fa0de346c8f68f4f3d27c8693d"},
@@ -3105,7 +2970,7 @@ version = "0.1.7"
 description = "Inline Matplotlib backend for Jupyter"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca"},
     {file = "matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90"},
@@ -3145,7 +3010,7 @@ version = "2.5.0"
 description = "Extremely lightweight compatibility layer between dataframe libraries"
 optional = false
 python-versions = ">=3.9"
-groups = ["vis"]
+groups = ["main", "vis"]
 markers = "python_version >= \"3.10\""
 files = [
     {file = "narwhals-2.5.0-py3-none-any.whl", hash = "sha256:7e213f9ca7db3f8bf6f7eff35eaee6a1cf80902997e1b78d49b7755775d8f423"},
@@ -3623,7 +3488,7 @@ version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
@@ -3788,7 +3653,7 @@ version = "0.8.5"
 description = "A Python Parser"
 optional = false
 python-versions = ">=3.6"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887"},
     {file = "parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a"},
@@ -3809,7 +3674,7 @@ version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
 optional = false
 python-versions = "*"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or python_version == \"3.9\" and sys_platform != \"win32\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
@@ -3830,7 +3695,7 @@ version = "11.3.0"
 description = "Python Imaging Library (Fork)"
 optional = false
 python-versions = ">=3.9"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860"},
     {file = "pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad"},
@@ -4017,7 +3882,7 @@ version = "5.24.1"
 description = "An open-source, interactive data visualization library for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "plotly-5.24.1-py3-none-any.whl", hash = "sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089"},
     {file = "plotly-5.24.1.tar.gz", hash = "sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae"},
@@ -4103,7 +3968,7 @@ version = "3.0.52"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
     {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
@@ -4152,12 +4017,12 @@ version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
 optional = false
 python-versions = "*"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
 ]
-markers = {dev = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or os_name != \"nt\" or python_version == \"3.9\" and sys_platform != \"win32\"", vis = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or python_version == \"3.9\" and sys_platform != \"win32\""}
+markers = {main = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or python_version == \"3.9\" and sys_platform != \"win32\"", dev = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or os_name != \"nt\" or python_version == \"3.9\" and sys_platform != \"win32\"", vis = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or python_version == \"3.9\" and sys_platform != \"win32\""}
 
 [package.source]
 type = "legacy"
@@ -4170,7 +4035,7 @@ version = "0.2.3"
 description = "Safely evaluate AST nodes without side effects"
 optional = false
 python-versions = "*"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
     {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
@@ -4237,12 +4102,12 @@ version = "2.23"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"},
     {file = "pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2"},
 ]
-markers = {dev = "implementation_name != \"PyPy\"", vis = "implementation_name == \"pypy\""}
+markers = {main = "implementation_name == \"pypy\"", dev = "implementation_name != \"PyPy\"", vis = "implementation_name == \"pypy\""}
 
 [package.source]
 type = "legacy"
@@ -4255,11 +4120,12 @@ version = "2.11.9"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pydantic-2.11.9-py3-none-any.whl", hash = "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2"},
     {file = "pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2"},
 ]
+markers = {dev = "python_version >= \"3.10\""}
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
@@ -4282,7 +4148,7 @@ version = "2.33.2"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pydantic_core-2.33.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2b3d326aaef0c0399d9afffeb6367d5e26ddc24d351dbc9c636840ac355dc5d8"},
     {file = "pydantic_core-2.33.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e5b2671f05ba48b94cb90ce55d8bdcaaedb8ba00cc5359f6810fc918713983d"},
@@ -4384,9 +4250,42 @@ files = [
     {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2807668ba86cb38c6817ad9bc66215ab8584d1d304030ce4f0887336f28a5e27"},
     {file = "pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc"},
 ]
+markers = {dev = "python_version >= \"3.10\""}
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+
+[package.source]
+type = "legacy"
+url = "https://pypi.org/simple"
+reference = "pypi-public"
+
+[[package]]
+name = "pydantic-extra-types"
+version = "2.11.1"
+description = "Extra Pydantic types."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+markers = "python_version >= \"3.10\""
+files = [
+    {file = "pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1"},
+    {file = "pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049"},
+]
+
+[package.dependencies]
+pydantic = ">=2.5.2"
+typing-extensions = "*"
+
+[package.extras]
+all = ["cron-converter (>=1.2.2)", "pendulum (>=3.0.0,<4.0.0)", "phonenumbers (>=8,<10)", "pycountry (>=23)", "pymongo (>=4.0.0,<5.0.0)", "python-ulid (>=1,<2) ; python_version < \"3.9\"", "python-ulid (>=1,<4) ; python_version >= \"3.9\"", "pytz (>=2024.1)", "semver (>=3.0.2)", "semver (>=3.0.2,<3.1.0)", "tzdata (>=2024.1)", "uuid-utils (>=0.6.0) ; python_version < \"3.14\""]
+cron = ["cron-converter (>=1.2.2)"]
+pendulum = ["pendulum (>=3.0.0,<4.0.0)"]
+phonenumbers = ["phonenumbers (>=8,<10)"]
+pycountry = ["pycountry (>=23)"]
+python-ulid = ["python-ulid (>=1,<2) ; python_version < \"3.9\"", "python-ulid (>=1,<4) ; python_version >= \"3.9\""]
+semver = ["semver (>=3.0.2)"]
+uuid-utils = ["uuid-utils (>=0.6.0) ; python_version < \"3.14\""]
 
 [package.source]
 type = "legacy"
@@ -4436,7 +4335,7 @@ version = "3.2.4"
 description = "pyparsing - Classes and methods to define and execute parsing grammars"
 optional = false
 python-versions = ">=3.9"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "pyparsing-3.2.4-py3-none-any.whl", hash = "sha256:91d0fcde680d42cd031daf3a6ba20da3107e08a75de50da58360e7d94ab24d36"},
     {file = "pyparsing-3.2.4.tar.gz", hash = "sha256:fff89494f45559d0f2ce46613b419f632bbb6afbdaed49696d322bcf98a58e99"},
@@ -4574,30 +4473,6 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
-name = "python-slugify"
-version = "8.0.4"
-description = "A Python slugify application that also handles Unicode"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856"},
-    {file = "python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8"},
-]
-
-[package.dependencies]
-text-unidecode = ">=1.3"
-Unidecode = {version = ">=1.1.1", optional = true, markers = "extra == \"unidecode\""}
-
-[package.extras]
-unidecode = ["Unidecode (>=1.1.1)"]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.org/simple"
-reference = "pypi-public"
-
-[[package]]
 name = "pytz"
 version = "2025.2"
 description = "World timezone definitions, modern and historical"
@@ -4679,7 +4554,7 @@ version = "6.0.2"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
@@ -4747,7 +4622,7 @@ version = "26.4.0"
 description = "Python bindings for 0MQ"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "pyzmq-26.4.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:0329bdf83e170ac133f44a233fc651f6ed66ef8e66693b5af7d54f45d1ef5918"},
     {file = "pyzmq-26.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:398a825d2dea96227cf6460ce0a174cf7657d6f6827807d4d1ae9d0f9ae64315"},
@@ -5363,7 +5238,7 @@ version = "0.13.2"
 description = "Statistical data visualization"
 optional = false
 python-versions = ">=3.8"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987"},
     {file = "seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7"},
@@ -5651,26 +5526,33 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
-name = "sphinx-material"
-version = "0.0.32"
-description = "Material sphinx theme"
+name = "sphinx-immaterial"
+version = "0.13.9"
+description = "Adaptation of mkdocs-material theme for the Sphinx documentation system"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.10"
 groups = ["dev"]
+markers = "python_version >= \"3.10\""
 files = [
-    {file = "sphinx_material-0.0.32-py3-none-any.whl", hash = "sha256:dadc6669c37950b222b5dd8f621191b5a49bd567f9c0eecd8d92ea5ca4210162"},
-    {file = "sphinx_material-0.0.32.tar.gz", hash = "sha256:ec02825a1bbe8b662fe624c11b87f1cd8d40875439b5b18c38649cf3366201fa"},
+    {file = "sphinx_immaterial-0.13.9-py3-none-any.whl", hash = "sha256:5ea92d2ddc6befcd0fedbd3e6766ea4746e94d9a8a5cc0ab092a946e1fde4254"},
 ]
 
 [package.dependencies]
-beautifulsoup4 = "*"
-css-html-js-minify = "*"
-lxml = "*"
-python-slugify = {version = "*", extras = ["unidecode"]}
-sphinx = ">=2.0"
+appdirs = "*"
+markupsafe = "*"
+pydantic = ">=2.4"
+pydantic-extra-types = "*"
+requests = "*"
+sphinx = ">=6"
+typing-extensions = "*"
 
 [package.extras]
-dev = ["black (==19.10b0)"]
+black = ["black"]
+clang-format = ["clang-format"]
+cpp = ["libclang"]
+json = ["pyyaml"]
+jsonschema-validation = ["jsonschema"]
+keys = ["pymdown-extensions"]
 
 [package.source]
 type = "legacy"
@@ -5941,7 +5823,7 @@ version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
 optional = false
 python-versions = "*"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
     {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
@@ -5966,7 +5848,7 @@ version = "9.1.2"
 description = "Retry code until it succeeds"
 optional = false
 python-versions = ">=3.9"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138"},
     {file = "tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb"},
@@ -6002,23 +5884,6 @@ tornado = ">=6.1.0"
 docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["pre-commit", "pytest (>=7.0)", "pytest-timeout"]
 typing = ["mypy (>=1.6,<2.0)", "traitlets (>=5.11.1)"]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.org/simple"
-reference = "pypi-public"
-
-[[package]]
-name = "text-unidecode"
-version = "1.3"
-description = "The most basic Text::Unidecode port"
-optional = false
-python-versions = "*"
-groups = ["dev"]
-files = [
-    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
-    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
-]
 
 [package.source]
 type = "legacy"
@@ -6103,7 +5968,7 @@ version = "6.5.2"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 optional = false
 python-versions = ">= 3.9"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "tornado-6.5.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:2436822940d37cde62771cff8774f4f00b3c8024fe482e16ca8387b8a2724db6"},
     {file = "tornado-6.5.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:583a52c7aa94ee046854ba81d9ebb6c81ec0fd30386d96f7640c96dad45a03ef"},
@@ -6118,7 +5983,7 @@ files = [
     {file = "tornado-6.5.2-cp39-abi3-win_arm64.whl", hash = "sha256:d6c33dc3672e3a1f3618eb63b7ef4683a7688e7b9e6e8f0d9aa5726360a004af"},
     {file = "tornado-6.5.2.tar.gz", hash = "sha256:ab53c8f9a0fa351e2c0741284e06c7a45da86afb544133201c5cc8578eb076a0"},
 ]
-markers = {vis = "sys_platform != \"emscripten\" or python_version == \"3.9\""}
+markers = {main = "sys_platform != \"emscripten\" or python_version == \"3.9\"", vis = "sys_platform != \"emscripten\" or python_version == \"3.9\""}
 
 [package.source]
 type = "legacy"
@@ -6131,7 +5996,7 @@ version = "5.14.3"
 description = "Traitlets Python configuration system"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"},
     {file = "traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"},
@@ -6205,11 +6070,12 @@ version = "0.4.1"
 description = "Runtime typing introspection tools"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51"},
     {file = "typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28"},
 ]
+markers = {dev = "python_version >= \"3.10\""}
 
 [package.dependencies]
 typing-extensions = ">=4.12.0"
@@ -6229,23 +6095,6 @@ groups = ["main", "vis"]
 files = [
     {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
     {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.org/simple"
-reference = "pypi-public"
-
-[[package]]
-name = "unidecode"
-version = "1.4.0"
-description = "ASCII transliterations of Unicode text"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021"},
-    {file = "Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23"},
 ]
 
 [package.source]
@@ -6329,7 +6178,7 @@ version = "0.2.13"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = "*"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 files = [
     {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
@@ -6402,7 +6251,7 @@ version = "4.0.14"
 description = "Jupyter interactive widgets for Jupyter Notebook"
 optional = false
 python-versions = ">=3.7"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "widgetsnbextension-4.0.14-py3-none-any.whl", hash = "sha256:4875a9eaf72fbf5079dc372a51a9f268fc38d46f767cbf85c43a36da5cb9b575"},
     {file = "widgetsnbextension-4.0.14.tar.gz", hash = "sha256:a3629b04e3edb893212df862038c7232f62973373869db5084aed739b437b5af"},
@@ -6515,7 +6364,7 @@ version = "2025.4.0"
 description = "Source of XYZ tiles providers"
 optional = false
 python-versions = ">=3.8"
-groups = ["vis"]
+groups = ["main", "vis"]
 files = [
     {file = "xyzservices-2025.4.0-py3-none-any.whl", hash = "sha256:8d4db9a59213ccb4ce1cf70210584f30b10795bff47627cdfb862b39ff6e10c9"},
     {file = "xyzservices-2025.4.0.tar.gz", hash = "sha256:6fe764713648fac53450fbc61a3c366cb6ae5335a1b2ae0c3796b495de3709d8"},
@@ -6532,7 +6381,7 @@ version = "3.23.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "vis"]
+groups = ["main", "dev", "vis"]
 markers = "python_version == \"3.9\""
 files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
@@ -6552,7 +6401,10 @@ type = "legacy"
 url = "https://pypi.org/simple"
 reference = "pypi-public"
 
+[extras]
+vis = ["bokeh", "jupyter-bokeh", "plotly", "pyzmq", "seaborn"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.14"
-content-hash = "648b4314dc2da81ae9c2b3ae4ebefe1e6e5563d935653ef8e194c07fd91a571e"
+content-hash = "39f612e13bdb4c46cbb4f1a9cd3c2426fd3e8a6d44229708f641bfe69a8f0cb2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ Sphinx = [
     { version = "^7.0.0", python = "<3.10" },
 ]
 sphinx-copybutton = "^0.3.1"
-sphinx-material = "^0.0.32"
+sphinx-immaterial = ">=0.13.0"
 sphinxcontrib-bibtex = "^2.1.4"
 pytest-xdist = "^3.6.1"
 coverage = "^7.6.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ Sphinx = [
     { version = "^7.0.0", python = "<3.10" },
 ]
 sphinx-copybutton = "^0.3.1"
-sphinx-immaterial = ">=0.13.0"
+sphinx-immaterial = {version = ">=0.13.0", python = ">=3.10"}
 sphinxcontrib-bibtex = "^2.1.4"
 pytest-xdist = "^3.6.1"
 coverage = "^7.6.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,14 @@ SQLAlchemy = ">=1.4.0"
 deprecated = "^1.2.14"
 pydantic = "^2.9.2"
 pint = "^0.24.4"
+bokeh = {version = "^3.0", optional = true}
+jupyter-bokeh = {version = "^4.0", optional = true}
+plotly = {version = "^5.0", optional = true}
+seaborn = {version = ">=0.12", optional = true}
+pyzmq = {version = "^26.0.0", optional = true}
+
+[tool.poetry.extras]
+vis = ["bokeh", "jupyter-bokeh", "plotly", "seaborn", "pyzmq"]
 
 
 [tool.poetry.group.dev.dependencies]

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,23 +8,27 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
-
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
+  fail_on_warning: false
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
   - epub
+  - pdf
 
 build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_install:
+      # Generate data documentation from PropertyMetadata
+      - inv render-data-docs
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:
     - method: pip
       path: .
+      extra_requirements:
+        - vis
     - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary

Major documentation overhaul focused on structure, navigation, and maintainability.

### Changes

**Theme migration**
- sphinx-material → sphinx-immaterial (drop-in fork, actively maintained)
- Updated conf.py: modern palette (light/dark), mkdocs-material features, removed deprecated options
- Workaround: disable `generate_synopses` to avoid upstream KeyError bug

**Navigation & structure**
- Split flat toctree into 4 captioned sections: Getting Started, Data & Features, API Reference, Community & Help
- New dedicated `citing.rst` page (citing, BibTeX/BibLaTeX, related projects, funding)
- Removed inline Quick Start examples from landing page (now links to `quick.rst`)
- Notebook descriptions added to `tutorials.rst`
- `api_overview.rst` duplicate code patterns replaced with compact decision table (-140 lines)

**Units documentation**
- Rewrote `units.rst` around the `_u` suffix API (the actual mechanism, not the manual ureg approach)
- Added complete property listing (80 properties across 6 classes) with units
- New `working_with_units.ipynb` tutorial notebook
- Updated `quick.rst` section 11 and `faq.rst` units answer to reference `_u` suffix

**Developer experience**
- AGENTS.md created with exact dev commands, architecture notes, key conventions
- `install.rst` expanded with development setup section

### Files changed
- `AGENTS.md` — new
- `docs/requirements.txt` — sphinx-material → sphinx-immaterial
- `docs/source/conf.py` — theme migration, palette, features, pyfiglet mock
- `docs/source/citing.rst` — new
- `docs/source/index.rst` — restructured toctree, trimmed landing page
- `docs/source/quick.rst` — rewritten as examples gallery, appendix extracted
- `docs/source/api_overview.rst` — decision guide at top, trimmed patterns
- `docs/source/install.rst` — expanded with dev setup
- `docs/source/tutorials.rst` — notebook descriptions added, units notebook added
- `docs/source/faq.rst` — cross-refs updated, units answer improved
- `docs/source/units.rst` — rewritten around _u suffix, full property listing
- `docs/source/notebooks/working_with_units.ipynb` — new tutorial

### Verification
- `cd docs && poetry run make html` succeeds (1234 pre-existing warnings, no new ones)
- pre-commit (ruff) passes on all modified files
- Notebook executes successfully

Closes #242